### PR TITLE
More verbosity when writing to Mixpanel fails

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -95,7 +95,7 @@ module Mixpanel
       if response.code == '200' and response.body == '1'
         return true
       else
-        raise ConnectionError.new('Could not write to Mixpanel')
+        raise ConnectionError.new("Could not write to Mixpanel, server responded with #{response.code} returning: '#{response.body}'")
       end
     end
   end

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -36,6 +36,11 @@ describe Mixpanel::Consumer do
     WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
       with(:body => { 'data' => 'IkJBU0U2NC1FTkNPREVEIFZFUlNJT04gT0YgQklOLiBUSElTIE1FVEhPRCBDT01QTElFUyBXSVRIIFJGQyAyMDQ1LiBMSU5FIEZFRURTIEFSRSBBRERFRCBUTyBFVkVSWSA2MCBFTkNPREVEIENIQVJBQ1RPUlMuIElOIFJVQlkgMS44IFdFIE5FRUQgVE8gSlVTVCBDQUxMIEVOQ09ERTY0IEFORCBSRU1PVkUgVEhFIExJTkUgRkVFRFMsIElOIFJVQlkgMS45IFdFIENBTEwgU1RSSUNfRU5DT0RFRDY0IE1FVEhPRCBJTlNURUFEIg==' })
   end
+
+  it 'should provide thorough information in case mixpanel fails' do
+    stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :status => 401, :body => "nutcakes" })
+    expect { @consumer.send(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception('Could not write to Mixpanel, server responded with 401 returning: \'nutcakes\'') 
+  end
 end
 
 describe Mixpanel::BufferedConsumer do


### PR DESCRIPTION
Hey!

Right now we're experiencing an occasional error where 'Could not write to Mixpanel' occurs. That's not a very helpful error message and hard to debug with, so here's a simple implementation of something more verbose :)

I haven't yet actually managed to reproduce the error with this patch, but hopefully his helps us and others.
