### PR TITLE
Add Faraday adapter

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -24,6 +24,14 @@ get started sending your first events and updates:
         'Best Album' => 'The Rise and Fall of Ziggy Stardust and the Spiders from Mars'
     })
 
+== Configuration
+
+You can change the default HTTP adapter (Net::HTTP) to Faraday:
+
+     require 'mixpanel-ruby/adapter/faraday'
+     Mixpanel.adapter = Mixpanel::Adapter::Faraday
+
+
 The primary class you will use to track events is Mixpanel::Tracker. An instance of
 Mixpanel::Tracker is enough to send events directly to \Mixpanel, and get you integrated
 right away.

--- a/lib/mixpanel-ruby/adapter/faraday.rb
+++ b/lib/mixpanel-ruby/adapter/faraday.rb
@@ -1,0 +1,19 @@
+require 'faraday'
+
+module Faraday
+  class Response
+    alias :code :status unless method_defined?(:code)
+  end
+end
+
+module Mixpanel
+  module Adapter
+    module Faraday
+      def self.request(endpoint, form_data)
+        conn = ::Faraday.new(endpoint)
+        Mixpanel.with_http(conn)
+        conn.post(nil, form_data)
+      end
+    end
+  end
+end

--- a/lib/mixpanel-ruby/adapter/net_http.rb
+++ b/lib/mixpanel-ruby/adapter/net_http.rb
@@ -1,0 +1,17 @@
+module Mixpanel
+  module Adapter
+    module NetHttp
+      def self.request(endpoint, form_data)
+        uri = URI(endpoint)
+        request = Net::HTTP::Post.new(uri.request_uri)
+        request.set_form_data(form_data)
+
+        client = Net::HTTP.new(uri.host, uri.port)
+        client.use_ssl = true
+        Mixpanel.with_http(client)
+
+        client.request(request)
+      end
+    end
+  end
+end

--- a/mixpanel-ruby.gemspec
+++ b/mixpanel-ruby.gemspec
@@ -14,4 +14,5 @@ spec = Gem::Specification.new do |spec|
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('webmock')
+  spec.add_development_dependency('faraday')
 end

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -2,42 +2,56 @@ require 'spec_helper'
 require 'webmock'
 require 'base64'
 require 'mixpanel-ruby/consumer'
+require 'mixpanel-ruby/adapter/faraday'
 
 describe Mixpanel::Consumer do
   before { WebMock.reset! }
 
-  it 'should send a request to api.mixpanel.com/track on events' do
-    stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :body => '{"status": 1, "error": null}' })
-    subject.send(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json)
-    WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
-      with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+  shared_examples_for 'consumer' do
+    it 'should send a request to api.mixpanel.com/track on events' do
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :body => '{"status": 1, "error": null}' })
+      subject.send(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json)
+      WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+    end
+
+    it 'should send a request to api.mixpanel.com/people on profile updates' do
+      stub_request(:any, 'https://api.mixpanel.com/engage').to_return({ :body => '{"status": 1, "error": null}' })
+      subject.send(:profile_update, {'data' => 'TEST EVENT MESSAGE'}.to_json)
+      WebMock.should have_requested(:post, 'https://api.mixpanel.com/engage').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+    end
+
+    it 'should send a request to api.mixpanel.com/import on event imports' do
+      stub_request(:any, 'https://api.mixpanel.com/import').to_return({ :body => '{"status": 1, "error": null}' })
+      subject.send(:import, {'data' => 'TEST EVENT MESSAGE', 'api_key' => 'API_KEY','verbose' => '1' }.to_json)
+      WebMock.should have_requested(:post, 'https://api.mixpanel.com/import').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'api_key' => 'API_KEY', 'verbose' => '1' })
+    end
+
+    it 'should encode long messages without newlines' do
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :body => '{"status": 1, "error": null}' })
+      subject.send(:event, { 'data' => 'BASE64-ENCODED VERSION OF BIN. THIS METHOD COMPLIES WITH RFC 2045. LINE FEEDS ARE ADDED TO EVERY 60 ENCODED CHARACTORS. IN RUBY 1.8 WE NEED TO JUST CALL ENCODE64 AND REMOVE THE LINE FEEDS, IN RUBY 1.9 WE CALL STRIC_ENCODED64 METHOD INSTEAD' }.to_json)
+      WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+        with(:body => { 'data' => 'IkJBU0U2NC1FTkNPREVEIFZFUlNJT04gT0YgQklOLiBUSElTIE1FVEhPRCBDT01QTElFUyBXSVRIIFJGQyAyMDQ1LiBMSU5FIEZFRURTIEFSRSBBRERFRCBUTyBFVkVSWSA2MCBFTkNPREVEIENIQVJBQ1RPUlMuIElOIFJVQlkgMS44IFdFIE5FRUQgVE8gSlVTVCBDQUxMIEVOQ09ERTY0IEFORCBSRU1PVkUgVEhFIExJTkUgRkVFRFMsIElOIFJVQlkgMS45IFdFIENBTEwgU1RSSUNfRU5DT0RFRDY0IE1FVEhPRCBJTlNURUFEIg==', 'verbose' => '1' })
+    end
+
+    it 'should provide thorough information in case mixpanel fails' do
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :status => 401, :body => "nutcakes" })
+      expect { subject.send(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception('Could not write to Mixpanel, server responded with 401 returning: \'nutcakes\'')
+    end
   end
 
-  it 'should send a request to api.mixpanel.com/people on profile updates' do
-    stub_request(:any, 'https://api.mixpanel.com/engage').to_return({ :body => '{"status": 1, "error": null}' })
-    subject.send(:profile_update, {'data' => 'TEST EVENT MESSAGE'}.to_json)
-    WebMock.should have_requested(:post, 'https://api.mixpanel.com/engage').
-      with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+  context 'Net::HTTP' do
+    before { Mixpanel.adapter = Mixpanel::Adapter::NetHttp }
+    it_behaves_like 'consumer'
   end
 
-  it 'should send a request to api.mixpanel.com/import on event imports' do
-    stub_request(:any, 'https://api.mixpanel.com/import').to_return({ :body => '{"status": 1, "error": null}' })
-    subject.send(:import, {'data' => 'TEST EVENT MESSAGE', 'api_key' => 'API_KEY','verbose' => '1' }.to_json)
-    WebMock.should have_requested(:post, 'https://api.mixpanel.com/import').
-      with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'api_key' => 'API_KEY', 'verbose' => '1' })
+  context 'Faraday' do
+    before { Mixpanel.adapter = Mixpanel::Adapter::Faraday }
+    it_behaves_like 'consumer'
   end
 
-  it 'should encode long messages without newlines' do
-    stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :body => '{"status": 1, "error": null}' })
-    subject.send(:event, { 'data' => 'BASE64-ENCODED VERSION OF BIN. THIS METHOD COMPLIES WITH RFC 2045. LINE FEEDS ARE ADDED TO EVERY 60 ENCODED CHARACTORS. IN RUBY 1.8 WE NEED TO JUST CALL ENCODE64 AND REMOVE THE LINE FEEDS, IN RUBY 1.9 WE CALL STRIC_ENCODED64 METHOD INSTEAD' }.to_json)
-    WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
-      with(:body => { 'data' => 'IkJBU0U2NC1FTkNPREVEIFZFUlNJT04gT0YgQklOLiBUSElTIE1FVEhPRCBDT01QTElFUyBXSVRIIFJGQyAyMDQ1LiBMSU5FIEZFRURTIEFSRSBBRERFRCBUTyBFVkVSWSA2MCBFTkNPREVEIENIQVJBQ1RPUlMuIElOIFJVQlkgMS44IFdFIE5FRUQgVE8gSlVTVCBDQUxMIEVOQ09ERTY0IEFORCBSRU1PVkUgVEhFIExJTkUgRkVFRFMsIElOIFJVQlkgMS45IFdFIENBTEwgU1RSSUNfRU5DT0RFRDY0IE1FVEhPRCBJTlNURUFEIg==', 'verbose' => '1' })
-  end
-
-  it 'should provide thorough information in case mixpanel fails' do
-    stub_request(:any, 'https://api.mixpanel.com/track').to_return({ :status => 401, :body => "nutcakes" })
-    expect { subject.send(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception('Could not write to Mixpanel, server responded with 401 returning: \'nutcakes\'')
-  end
 end
 
 describe Mixpanel::BufferedConsumer do


### PR DESCRIPTION
This change extracts the HTTP functionality to an Adapter module and adds Faraday support, while being fully backward compatible.
I also cleaned up the spec a bit.
