### PR TITLE
RSpec 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 html
 mixpanel-ruby*.gem
+.bundle

--- a/mixpanel-ruby.gemspec
+++ b/mixpanel-ruby.gemspec
@@ -12,6 +12,6 @@ spec = Gem::Specification.new do |spec|
   spec.homepage = 'https://mixpanel.com/help/reference/ruby'
 
   spec.add_development_dependency('rake')
-  spec.add_development_dependency('rspec')
-  spec.add_development_dependency('webmock')
+  spec.add_development_dependency('rspec', '~> 3.0.0')
+  spec.add_development_dependency('webmock', '~> 1.18.0')
 end

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -10,28 +10,28 @@ describe Mixpanel::Consumer do
     it 'should send a request to api.mixpanel.com/track on events' do
       stub_request(:any, 'https://api.mixpanel.com/track').to_return({:body => '{"status": 1, "error": null}'})
       subject.send(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json)
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
     it 'should send a request to api.mixpanel.com/people on profile updates' do
       stub_request(:any, 'https://api.mixpanel.com/engage').to_return({:body => '{"status": 1, "error": null}'})
       subject.send(:profile_update, {'data' => 'TEST EVENT MESSAGE'}.to_json)
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/engage').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/engage').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
     it 'should send a request to api.mixpanel.com/import on event imports' do
       stub_request(:any, 'https://api.mixpanel.com/import').to_return({:body => '{"status": 1, "error": null}'})
       subject.send(:import, {'data' => 'TEST EVENT MESSAGE', 'api_key' => 'API_KEY','verbose' => '1' }.to_json)
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/import').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/import').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'api_key' => 'API_KEY', 'verbose' => '1' })
     end
 
     it 'should encode long messages without newlines' do
       stub_request(:any, 'https://api.mixpanel.com/track').to_return({:body => '{"status": 1, "error": null}'})
       subject.send(:event, {'data' => 'BASE64-ENCODED VERSION OF BIN. THIS METHOD COMPLIES WITH RFC 2045. LINE FEEDS ARE ADDED TO EVERY 60 ENCODED CHARACTORS. IN RUBY 1.8 WE NEED TO JUST CALL ENCODE64 AND REMOVE THE LINE FEEDS, IN RUBY 1.9 WE CALL STRIC_ENCODED64 METHOD INSTEAD'}.to_json)
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IkJBU0U2NC1FTkNPREVEIFZFUlNJT04gT0YgQklOLiBUSElTIE1FVEhPRCBDT01QTElFUyBXSVRIIFJGQyAyMDQ1LiBMSU5FIEZFRURTIEFSRSBBRERFRCBUTyBFVkVSWSA2MCBFTkNPREVEIENIQVJBQ1RPUlMuIElOIFJVQlkgMS44IFdFIE5FRUQgVE8gSlVTVCBDQUxMIEVOQ09ERTY0IEFORCBSRU1PVkUgVEhFIExJTkUgRkVFRFMsIElOIFJVQlkgMS45IFdFIENBTEwgU1RSSUNfRU5DT0RFRDY0IE1FVEhPRCBJTlNURUFEIg==', 'verbose' => '1'})
     end
 
@@ -60,7 +60,7 @@ describe Mixpanel::Consumer do
     end
 
     after(:each) do
-      subject.called.should be_true
+      expect(subject.called).to be_truthy
     end
 
     it_behaves_like 'consumer'
@@ -78,10 +78,10 @@ describe Mixpanel::BufferedConsumer do
     it 'should not send a request for a single message until flush is called' do
       stub_request(:any, 'https://api.mixpanel.com/track').to_return({:body => '{"status": 1, "error": null}'})
       subject.send(:event, {'data' => 'TEST EVENT 1'}.to_json)
-      WebMock.should have_not_requested(:post, 'https://api.mixpanel.com/track')
+      expect(WebMock).to have_not_requested(:post, 'https://api.mixpanel.com/track')
 
       subject.flush()
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'WyJURVNUIEVWRU5UIDEiXQ==', 'verbose' => '1' })
     end
 
@@ -92,7 +92,7 @@ describe Mixpanel::BufferedConsumer do
         subject.send(:event, {'data' => "x #{i}"}.to_json)
       end
 
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'WyJ4IDAiLCJ4IDEiLCJ4IDIiLCJ4IDMiLCJ4IDQiLCJ4IDUiLCJ4IDYiLCJ4IDciLCJ4IDgiLCJ4IDkiXQ==', 'verbose' => '1' })
     end
 
@@ -104,10 +104,10 @@ describe Mixpanel::BufferedConsumer do
       subject.send(:import, {'data' => 'TEST EVENT 2', 'api_key' => 'KEY 2'}.to_json)
       subject.flush
 
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/import').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/import').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgMSI=', 'api_key' => 'KEY 1', 'verbose' => '1' })
 
-      WebMock.should have_requested(:post, 'https://api.mixpanel.com/import').
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/import').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgMSI=', 'api_key' => 'KEY 2', 'verbose' => '1' })
     end
   end

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -6,7 +6,7 @@ require 'time'
 describe Mixpanel::Events do
   before(:each) do
     @time_now = Time.parse('Jun 6 1972, 16:23:04')
-    Time.stub(:now).and_return(@time_now)
+    allow(Time).to receive(:now).and_return(@time_now)
 
     @log = []
     @events = Mixpanel::Events.new('TEST TOKEN') do |type, message|
@@ -18,7 +18,7 @@ describe Mixpanel::Events do
     @events.track('TEST ID', 'Test Event', {
         'Circumstances' => 'During a test'
     })
-    @log.should eq([[:event, 'data' => {
+    expect(@log).to eq([[:event, 'data' => {
         'event' => 'Test Event',
         'properties' => {
             'Circumstances' => 'During a test',
@@ -35,7 +35,7 @@ describe Mixpanel::Events do
     @events.import('API_KEY', 'TEST ID', 'Test Event', {
         'Circumstances' => 'During a test'
     })
-    @log.should eq([[:import, {
+    expect(@log).to eq([[:import, {
         'api_key' => 'API_KEY',
         'data' => {
             'event' => 'Test Event',

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -4,7 +4,7 @@ require 'mixpanel-ruby/people'
 describe Mixpanel::People do
   before(:each) do
     @time_now = Time.parse('Jun 6 1972, 16:23:04')
-    Time.stub(:now).and_return(@time_now)
+    allow(Time).to receive(:now).and_return(@time_now)
 
     @log = []
     @people = Mixpanel::People.new('TEST TOKEN') do |type, message|
@@ -17,7 +17,7 @@ describe Mixpanel::People do
         '$firstname' => 'David',
         '$lastname' => 'Bowie',
     })
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -32,7 +32,7 @@ describe Mixpanel::People do
     @people.set("TEST ID", {
         'created_at' => DateTime.new(2013, 1, 2, 3, 4, 5)
     })
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -47,7 +47,7 @@ describe Mixpanel::People do
         '$firstname' => 'David',
         '$lastname' => 'Bowie',
     })
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -60,7 +60,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed engage/add message' do
     @people.increment("TEST ID", {'Albums Released' => 10})
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -72,7 +72,7 @@ describe Mixpanel::People do
 
   it 'should send an engage/add message with a value of 1' do
     @people.plus_one("TEST ID", 'Albums Released')
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -84,7 +84,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed engage/append message' do
     @people.append("TEST ID", {'Albums' => 'Diamond Dogs'})
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -96,7 +96,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed engage/union message' do
     @people.union("TEST ID", {'Albums' => ['Diamond Dogs']})
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -108,7 +108,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed unset message' do
     @people.unset('TEST ID', 'Albums')
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -118,7 +118,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed unset message with multiple properties' do
     @people.unset('TEST ID', ['Albums', 'Vinyls'])
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -131,7 +131,7 @@ describe Mixpanel::People do
         '$time' => DateTime.new(1999,12,24,14, 02, 53),
         'SKU' => '1234567'
     })
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -147,7 +147,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed engage/unset message for $transaction' do
     @people.clear_charges("TEST ID")
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
@@ -157,7 +157,7 @@ describe Mixpanel::People do
 
   it 'should send a well formed engage/delete message' do
     @people.delete_user("TEST ID")
-    @log.should eq([[:profile_update, 'data' => {
+    expect(@log).to eq([[:profile_update, 'data' => {
         '$token' => 'TEST TOKEN',
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,

--- a/spec/mixpanel-ruby/tracker_spec.rb
+++ b/spec/mixpanel-ruby/tracker_spec.rb
@@ -6,7 +6,7 @@ require 'uri'
 describe Mixpanel::Tracker do
   before(:each) do
     @time_now = Time.parse('Jun 6 1972, 16:23:04')
-    Time.stub(:now).and_return(@time_now)
+    allow(Time).to receive(:now).and_return(@time_now)
   end
 
   it 'should send an alias message to mixpanel no matter what the consumer is' do
@@ -15,7 +15,7 @@ describe Mixpanel::Tracker do
     mixpanel = Mixpanel::Tracker.new('TEST TOKEN') {|*args| }
     mixpanel.alias('TEST ALIAS', 'TEST ID')
 
-    WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+    expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
       with(:body => {:data => 'eyJldmVudCI6IiRjcmVhdGVfYWxpYXMiLCJwcm9wZXJ0aWVzIjp7ImRpc3RpbmN0X2lkIjoiVEVTVCBJRCIsImFsaWFzIjoiVEVTVCBBTElBUyIsInRva2VuIjoiVEVTVCBUT0tFTiJ9fQ==', 'verbose' => '1'})
   end
 
@@ -28,13 +28,13 @@ describe Mixpanel::Tracker do
     mixpanel.track('TEST ID', 'TEST EVENT', {'Circumstances' => 'During test'})
 
     body = nil
-    WebMock.should have_requested(:post, 'https://api.mixpanel.com/track').
+    expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
       with { |req| body = req.body }
 
     message_urlencoded = body[/^data=(.*?)(?:&|$)/, 1]
     message_json = Base64.strict_decode64(URI.unescape(message_urlencoded))
     message = JSON.load(message_json)
-    message.should eq({
+    expect(message).to eq({
         'event' => 'TEST EVENT',
         'properties' => {
             'Circumstances' => 'During test',
@@ -99,7 +99,7 @@ describe Mixpanel::Tracker do
         ]
     ]
     expect.zip(messages).each do |expect, found|
-      expect.should eq(found)
+      expect(expect).to eq(found)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,9 @@ require 'webmock/rspec'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+  config.raise_errors_for_deprecations!
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
RSpec 3's syntax is much clearer. This PR:
- Specifies the RSpec and WebMock versions in the gemspec
- Updates all specs to use the new RSpec syntax
- Configures RSpec to raise an exception if anyone writes old-syntax specs
- Adds `.bundle` to the `.gitignore` file (for all us rbenv users)

Needless to say they build is green.
