### PR TITLE
raise error if token is passed into track-properties

### DIFF
--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -48,6 +48,7 @@ module Mixpanel
     #         'User Sign-up Cohort' => 'July 2013'
     #     })
     def track(distinct_id, event, properties={}, ip=nil)
+      raise ArgumentError, "Reserved property 'token' passed into properties. Use constructor instead!" if properties['token'] || properties[:token]
       properties = {
           'distinct_id' => distinct_id,
           'token' => @token,

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -50,5 +50,11 @@ describe Mixpanel::Events do
         }
     } ]])
   end
+
+  it 'should raise error on #track if token is passed in the properties' do
+    expect{ @events.track('TEST ID', 'TEST EVENT',{
+      'token' => 'ANY VALUE'
+    }) }.to raise_error
+  end
 end
 


### PR DESCRIPTION
I an invalid token is passed into the track-properties, it overwrites the valid one set by the constructor. This leads to silent errors with missing events if we don't raise it explicitly! 