### PR TITLE
Added argument in people.set people.set_once & tracker.alias to accept a buffered_consumer

### DIFF
--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -55,11 +55,11 @@ module Mixpanel
     #        tracker.people.set("1234", {
     #        'company' => 'Acme',
     #        'plan' => 'Premium',
-    #        'Sign-Up Date' => DateTime.now
-    #    },nil,{},buffered_consumer = Mixpanel::BufferedConsumer.new);
+    #        'Sign-Up Date' => DateTime.now},
+    #         nil,{},buffered_consumer);
     #    buffered_consumer.flush
     def set(distinct_id, properties, ip=nil, optional_params={}, consumer=nil)
-      @sink = consumer if consumer.is_a? Mixpanel::BufferedConsumer 
+      @sink = consumer.method(:send) if consumer.is_a? Mixpanel::BufferedConsumer 
       properties = fix_property_dates(properties)
       message = {
           '$distinct_id' => distinct_id,
@@ -86,7 +86,7 @@ module Mixpanel
     # If a BufferedConsumer is passed in it will call 
     # send on that buffer. Make sure to flush after it is done
     def set_once(distinct_id, properties, ip=nil, optional_params={}, consumer=nil)
-      @sink = consumer if consumer.is_a? Mixpanel::BufferedConsumer 
+      @sink = consumer.method(:send) if consumer.is_a? Mixpanel::BufferedConsumer 
       properties = fix_property_dates(properties)
       message = {
           '$distinct_id' => distinct_id,
@@ -251,21 +251,17 @@ module Mixpanel
     # The \Mixpanel HTTP tracking API is documented at
     # https://mixpanel.com/help/reference/http
     def update(message)
-    data = {
-      '$token' => @token,
-      '$time' =>  ((Time.now.to_f) * 1000.0).to_i
-    }.merge(message)
+      data = {
+        '$token' => @token,
+        '$time' =>  ((Time.now.to_f) * 1000.0).to_i
+      }.merge(message)
 
-    message = {
-      'data' => data
-    }
+      message = {
+        'data' => data
+      }
 
-    if @sink.is_a? Mixpanel::BufferedConsumer 
-      @sink.send(:profile_update, message.to_json)
-    else  
       @sink.call(:profile_update, message.to_json)
     end
-  end
 
     private
 

--- a/lib/mixpanel-ruby/tracker.rb
+++ b/lib/mixpanel-ruby/tracker.rb
@@ -111,10 +111,8 @@ module Mixpanel
     # the \Mixpanel service, regardless of how the tracker is configured.
     # If a BufferedConsumer is passed in it will call 
     # send on that buffer. Make sure to flush after it is done
-    def alias(alias_id, real_id, events_endpoint=nil, consumer=nil)
-      if not consumer.is_a? Mixpanel::BufferedConsumer 
-        consumer = Mixpanel::Consumer.new(events_endpoint)
-      end
+    def alias(alias_id, real_id, events_endpoint=nil, consumer=nil) 
+      consumer ||= Mixpanel::Consumer.new(events_endpoint)
       data = {
         'event' => '$create_alias',
         'properties' => {


### PR DESCRIPTION
This will allow batch jobs of sending many requests to Mixpanel much faster (~30 times faster).
Please see comments in people.rb line 48 for an example on how to use. 
