### PR TITLE
Preserve timezone when calling #fix_property_dates.

### DIFF
--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -250,7 +250,7 @@ module Mixpanel
 
     def fix_property_dates(h)
       h.inject({}) do |ret,(k,v)|
-        ret[k] = v.respond_to?(:strftime) ? v.strftime('%Y-%m-%dT%H:%M:%S') : v
+        ret[k] = v.respond_to?(:strftime) ? v.strftime('%Y-%m-%dT%H:%M:%S%:z') : v
         ret
       end
     end

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -37,7 +37,7 @@ describe Mixpanel::People do
         '$distinct_id' => 'TEST ID',
         '$time' => @time_now.to_i * 1000,
         '$set' => {
-            'created_at' => '2013-01-02T03:04:05'
+            'created_at' => '2013-01-02T03:04:05+00:00'
         }
     }]])
   end
@@ -128,7 +128,7 @@ describe Mixpanel::People do
 
   it 'should send an engage/append with the right $transaction stuff' do
     @people.track_charge("TEST ID", 25.42, {
-        '$time' => DateTime.new(1999,12,24,14, 02, 53),
+        '$time' => DateTime.new(1999,12,24,14, 02, 53, '+9'),
         'SKU' => '1234567'
     })
     expect(@log).to eq([[:profile_update, 'data' => {
@@ -137,7 +137,7 @@ describe Mixpanel::People do
         '$time' => @time_now.to_i * 1000,
         '$append' => {
             '$transactions' => {
-                '$time' => '1999-12-24T14:02:53',
+                '$time' => '1999-12-24T14:02:53+09:00',
                 'SKU' => '1234567',
                 '$amount' => 25.42
             }


### PR DESCRIPTION
Before this patch, all dates sent to Mixpanel are considered on
UTC+0. This patch adds the timezone to the string format used to
convert DateTime objects to strings before sending them to Mixpanel.
I have confirmed that Mixpanel is able to parse this format.
See #49.
