### PR TITLE
Catch all connection errors

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -3,10 +3,13 @@ require 'net/https'
 require 'json'
 
 module Mixpanel
-  class ConnectionError < IOError
+  class MixpanelError < Error
   end
   
-  class ServerError < IOError
+  class ConnectionError < MixpanelError
+  end
+  
+  class ServerError < MixpanelError
   end
 
   @@init_http = nil

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -3,7 +3,7 @@ require 'net/https'
 require 'json'
 
 module Mixpanel
-  class MixpanelError < Error
+  class MixpanelError < Exception
   end
   
   class ConnectionError < MixpanelError

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -93,7 +93,7 @@ module Mixpanel
 
       begin
         response_code, response_body = request(endpoint, form_data)
-      rescue Exception e
+      rescue Exception => e
         raise ConnectionError.new("Could not connect to Mixpanel, with error \"#{e.message}\".")
       end
 


### PR DESCRIPTION
See #51.

Mixpanel was down for an hour this morning, and our logs are full of various errors:
 - EOFError
 - Errno::ECONNRESET
 - OpenSSL::SSL::SSLError
 - Errno::ECONNREFUSED
 - Net::ReadTimeout
 - Mixpanel::ConnectionError

I think that all these Exceptions should be caught by Mixpanel gem, and then raised as a Mixpanel error.

This pull request is just an untested draft, to get the discussion going.