### PR TITLE
Set timeouts

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -115,6 +115,11 @@ module Mixpanel
 
       client = Net::HTTP.new(uri.host, uri.port)
       client.use_ssl = true
+      client.open_timeout = 2
+      client.continue_timeout = 10
+      client.read_timeout = 10
+      client.ssl_timeout = 2
+
       Mixpanel.with_http(client)
 
       response = client.request(request)


### PR DESCRIPTION
Net::HTTP doesn't have default timeouts on open, continue, read or ssl. This sets them, so the client will timeout if it doesn't hear back from you guys.

Without this, any asynchronous jobs that use this client will hang if they don't hear back from you.