### PR TITLE
Batch requests

### DIFF
--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -112,5 +112,61 @@ module Mixpanel
 
       @sink.call(:import, message.to_json)
     end
+
+    # Notes that a batch of events has occurred for a distinct_id
+    # Events should be passed as an array, with each element either a
+    # Hash or a string. Each Hash element should have a single key (the event name,
+    # as a string) with the value a Hash of properties. Each string element
+    # will be interpreted as an event name with no properties.
+    #
+    #     tracker = Mixpanel::Tracker.new
+    #
+    #     tracker.track_batch("12345", [
+    #     "Signup Begin",
+    #     {
+    #       "Signup Complete" => {
+    #         'User Sign-up Cohort' => 'July 2013'
+    #       }
+    #     },
+    #     {
+    #       "Welcome Email Sent" => {
+    #         'Email Template' => 'Pretty Pink Welcome',
+    #         'User Sign-up Cohort' => 'July 2013'
+    #       }
+    #     }])
+    def track_batch(distinct_id, events, ip=nil)
+      data = events.map do |event_name_or_hash|
+        event = event_name_or_hash
+        properties = {}
+
+        if event_name_or_hash.is_a?(Hash)
+          event_data = event_name_or_hash.flatten
+          event = event_data[0]
+          properties = event_data[1]
+        end
+
+        properties = {
+          'distinct_id' => distinct_id,
+          'token' => @token,
+          'time' => Time.now.to_i,
+          'mp_lib' => 'ruby',
+          '$lib_version' => Mixpanel::VERSION
+        }.merge(properties)
+
+        properties['ip'] = ip if ip
+
+        {
+          'event' => event,
+          'properties' => properties
+        }
+      end
+
+      data.each_slice(50) do |slice|
+        message = { 'data' => slice }
+
+        @sink.call(:event, message.to_json)
+      end
+    end
+
   end
 end

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -14,6 +14,13 @@ module Mixpanel
   #     tracker.people.set(...) # Or .append(..), or track_charge(...) etc.
   class People
 
+    VALID_OPERATIONS = [
+      '$set', '$set_once', '$add', '$append', '$union', '$unset', '$delete'
+    ]
+    ADDITIVE_OPERATIONS = [
+      '$set', '$set_once', '$increment', '$append', '$union', '$track_charge'
+    ]
+
     # You likely won't need to instantiate instances of Mixpanel::People
     # directly. The best way to get an instance of Mixpanel::People is
     #
@@ -248,7 +255,69 @@ module Mixpanel
       @sink.call(:profile_update, message.to_json)
     end
 
+    # Send a generic batch update to \Mixpanel people analytics.
+    # The profile updates should be passed as an array of Hash objects.
+    # Each has should have a single string key that is the distinct id
+    # on which the perform the updates. The value should be a Hash with valid
+    # operation names (e.g. '$set', '$unset') as keys and the appropriate data
+    # for each operation as values. For details about the operations and their
+    # expected data, see the documentation at # https://mixpanel.com/help/reference/http
+    #
+    #    tracker = Mixpanel::Tracker.new
+    #
+    #    tracker.people.batch([
+    #      {
+    #        "12345" => {
+    #            '$set' => {
+    #                '$firstname' => 'David'
+    #            },
+    #            '$unset' => ['Levels Completed']
+    #        }
+    #      },
+    #      {
+    #        "67890" => {
+    #            '$set' => {
+    #                '$firstname' => 'Mick'
+    #            },
+    #            '$unset' => ['Levels Completed']
+    #        }
+    #      }
+    #    ])
+    def batch(profile_updates, ip=nil, optional_params={})
+      messages = []
+      profile_updates.each do |profile_update|
+        profile_update.each_pair do |distinct_id, updates|
+          updates.select! { |key, value| VALID_OPERATIONS.include?(key) }
+          updates.each_pair do |operation, data|
+            data = fix_property_dates(data) if ADDITIVE_OPERATIONS.include?(operation)
+
+            message = {
+                '$distinct_id' => distinct_id,
+                operation => data
+            }.merge(optional_params)
+            message['$ip'] = ip if ip
+            messages << message
+          end
+        end
+      end
+
+      messages.each_slice(50) { |slice| batch_update(slice) }
+    end
+
     private
+
+    def batch_update(messages)
+      data = messages.map do |message|
+        {
+          '$token' => @token,
+          '$time' =>  ((Time.now.to_f) * 1000.0).to_i
+        }.merge(message)
+      end
+
+      message = { 'data' => data }
+
+      @sink.call(:profile_update, message.to_json)
+    end
 
     def fix_property_dates(h)
       h.inject({}) do |ret,(k,v)|

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -50,5 +50,76 @@ describe Mixpanel::Events do
         }
     } ]])
   end
+
+  it 'should send a well formed batch track/ message' do
+    events = [
+      { 'Test Event' => {
+          'Circumstances' => 'During a test'
+      }},
+      { 'Other Event' => {
+          'Circumstances' => 'During a different test'
+      }},
+      "Event Without Properties"
+    ]
+    @events.track_batch('TEST ID', events)
+
+    expect(@log).to eq([[:event, 'data' => [
+      {
+        'event' => 'Test Event',
+        'properties' => {
+            'distinct_id' => 'TEST ID',
+            'token' => 'TEST TOKEN',
+            'time' => @time_now.to_i,
+            'mp_lib' => 'ruby',
+            '$lib_version' => Mixpanel::VERSION,
+            'Circumstances' => 'During a test',
+        }
+      },
+      {
+        'event' => 'Other Event',
+        'properties' => {
+            'distinct_id' => 'TEST ID',
+            'token' => 'TEST TOKEN',
+            'time' => @time_now.to_i,
+            'mp_lib' => 'ruby',
+            '$lib_version' => Mixpanel::VERSION,
+            'Circumstances' => 'During a different test',
+        }
+      },
+      {
+        'event' => 'Event Without Properties',
+        'properties' => {
+            'distinct_id' => 'TEST ID',
+            'token' => 'TEST TOKEN',
+            'time' => @time_now.to_i,
+            'mp_lib' => 'ruby',
+            '$lib_version' => Mixpanel::VERSION
+        }
+      }
+    ]]])
+  end
+
+  it 'should send track/ messages in batches of 50' do
+    events = Array.new(75, "Some Event")
+    batches = 75.times.map do |i|
+      {
+        'event' => 'Some Event',
+        'properties' => {
+            'distinct_id' => 'TEST ID',
+            'token' => 'TEST TOKEN',
+            'time' => @time_now.to_i,
+            'mp_lib' => 'ruby',
+            '$lib_version' => Mixpanel::VERSION
+        }
+      }
+    end
+
+    @events.track_batch('TEST ID', events)
+    expect(@log).to eq([
+      [:event, { 'data' => batches[0, 50] }],
+      [:event, { 'data' => batches[50, 25] }]
+    ])
+  end
+
 end
 

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -200,4 +200,82 @@ describe Mixpanel::People do
     }]])
   end
 
+  describe "batch operations" do
+
+    it 'should send a well formed batch engage/set message' do
+      @people.batch([{
+          "TEST ID" => {
+              '$set' => {
+                  '$firstname' => 'David',
+                  '$lastname' => 'Bowie',
+              },
+              '$unset' => ['Levels Completed']
+          }
+      }])
+      expect(@log).to eq([
+        [:profile_update, 'data' => [
+          {
+              '$token' => 'TEST TOKEN',
+              '$time' => @time_now.to_i * 1000,
+              '$distinct_id' => 'TEST ID',
+              '$set' => {
+                  '$firstname' => 'David',
+                  '$lastname' => 'Bowie'
+              }
+          },
+          {
+              '$token' => 'TEST TOKEN',
+              '$time' => @time_now.to_i * 1000,
+              '$distinct_id' => 'TEST ID',
+              '$unset' => ['Levels Completed']
+          },
+        ]
+      ]])
+    end
+
+    it 'should send batch engage/ message in batches of 50' do
+      profile_updates = 75.times.map do |i|
+        { "TEST ID" => { '$set' => { "prop_#{i}" => 'David' } } }
+      end
+
+      batches = 75.times.map do |i|
+        {
+            '$token' => 'TEST TOKEN',
+            '$distinct_id' => 'TEST ID',
+            '$time' => @time_now.to_i * 1000,
+            '$set' => { "prop_#{i}" => 'David' }
+        }
+      end
+
+      @people.batch(profile_updates)
+      expect(@log).to eq([
+        [:profile_update, 'data' => batches[0, 50]],
+        [:profile_update, 'data' => batches[50, 25]]
+      ])
+    end
+
+    it 'should reject invalid operations' do
+      @people.batch([{
+          'TEST ID' => {
+              '$set' => {
+                  '$firstname' => 'David',
+                  '$lastname' => 'Bowie',
+              },
+              '$foo' => {
+                  '$bar' => 'baz',
+              }
+          }
+      }])
+      expect(@log).to eq([[:profile_update, 'data' => [{
+          '$token' => 'TEST TOKEN',
+          '$distinct_id' => 'TEST ID',
+          '$time' => @time_now.to_i * 1000,
+          '$set' => {
+              '$firstname' => 'David',
+              '$lastname' => 'Bowie'
+          }
+      }]]])
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds `Mixpanel::People#batch` and `Mixpanel::Events#track_batch` methods to support batching requests. The `People#batch` method can be used to update people properties across multiple distinct ids, whereas the `Events#track_batch` will track multiple events for a single distinct id. These seemed to be the most common use cases, and worked for our purposes. 

I decided to use `Mixpanel::Events#track_batch` instead of `Mixpanel::Events#batch` because I thought it was a bit more declarative when used on a `Mixpanel::Tracker` instance. 

Both methods split the messages into groups of 50, so it is safe to pass in as many as you can safely store in memory.

We've had to update hundreds of thousands of users, and the combination of batch operations running on parallel background jobs has been invaluable. Hopefully these methods will be useful for others.

Please let me know if this is something you'd like to include in mixpanel-ruby and if there is anything I need to change in this PR. 