### PR TITLE
Raise ServerError when response is not a hash

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -107,7 +107,8 @@ module Mixpanel
           succeeded = result['status'] == 1
         rescue JSON::JSONError
           {}
-        #  raise ServerError.new("Could not parse response, with error \"#{e.message}\".")
+        rescue => e
+          raise ServerError.new("Could not read 'status' key from response, with error \"#{e.message}\".")
         end
       end
 

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -102,8 +102,13 @@ module Mixpanel
 
       succeeded = nil
       if response_code.to_i == 200
-        result = JSON.load(response_body) rescue {}
-        succeeded = result['status'] == 1
+        begin
+          result = JSON.load(response_body)
+          succeeded = result['status'] == 1
+        rescue JSON::JSONError
+          {}
+        #  raise ServerError.new("Could not parse response, with error \"#{e.message}\".")
+        end
       end
 
       if !succeeded

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -54,6 +54,13 @@ describe Mixpanel::Consumer do
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
+    it 'should raise server error when response does not contain key status' do
+      # when verbose is disabled, 'verbose' => '1' is ignored, and the response is just 0 even on success
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '0'})
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not read 'status' key from response, with error/)
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+    end
   end
 
   context 'raw consumer' do

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -46,6 +46,14 @@ describe Mixpanel::Consumer do
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
+
+    it 'should raise server error due to a json error' do
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '{'})
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not write to Mixpanel, server responded with 200/)
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+    end
+
   end
 
   context 'raw consumer' do


### PR DESCRIPTION
When mixpanel is configured to not allow verbose, the response is returned as '0' even on success. This causes a problem since the gem expects a hash, when `JSON.load(0)` returns 0, so a TypeError is raised. I wasn't sure which type of Error to use, but I imagine a ServerError could hint at a mixpanel configuration problem.