### PR TITLE
Minor handle json errors

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -107,7 +107,8 @@ module Mixpanel
           succeeded = result['status'] == 1
         rescue JSON::JSONError
           {}
-        #  raise ServerError.new("Could not parse response, with error \"#{e.message}\".")
+        rescue => e
+          raise ServerError.new("Could not read 'status' key from response, with error \"#{e.message}\".")
         end
       end
 

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -102,14 +102,8 @@ module Mixpanel
 
       succeeded = nil
       if response_code.to_i == 200
-        begin
-          result = JSON.load(response_body)
-          succeeded = result['status'] == 1
-        rescue JSON::JSONError
-          {}
-        rescue => e
-          raise ServerError.new("Could not read 'status' key from response, with error \"#{e.message}\".")
-        end
+        result = JSON.parse(response_body) rescue {}
+        succeeded = result['status'] == 1
       end
 
       if !succeeded

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -100,13 +100,16 @@ module Mixpanel
         raise ConnectionError.new("Could not connect to Mixpanel, with error \"#{e.message}\".")
       end
 
-      succeeded = nil
+      result = {}
       if response_code.to_i == 200
-        result = JSON.parse(response_body) rescue {}
-        succeeded = result['status'] == 1
+        begin
+          result = JSON.parse(response_body.to_s)
+        rescue JSON::JSONError
+          raise ServerError.new("Could not interpret Mixpanel server response: '#{response_body}'")
+        end
       end
 
-      if !succeeded
+      if result['status'] != 1
         raise ServerError.new("Could not write to Mixpanel, server responded with #{response_code} returning: '#{response_body}'")
       end
     end

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -102,8 +102,13 @@ module Mixpanel
 
       succeeded = nil
       if response_code.to_i == 200
-        result = JSON.load(response_body) rescue {}
-        succeeded = result['status'] == 1
+        begin
+          result = JSON.load(response_body)
+          succeeded = result['status'] == 1
+        rescue JSON::JSONError
+          {}
+        #  raise ServerError.new("Could not parse response, with error \"#{e.message}\".")
+        end
       end
 
       if !succeeded

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -48,15 +48,14 @@ describe Mixpanel::Consumer do
     end
 
     it 'should raise server error if response body is empty' do
-      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => ''})
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:body => ''})
       expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not interpret Mixpanel server response: ''/)
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
     it 'should raise server error when verbose is disabled' do
-      # when verbose is disabled, 'verbose' => '1' is ignored, and the response is just 0 even on success
-      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '0'})
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:body => '0'})
       expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not interpret Mixpanel server response: '0'/)
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -47,17 +47,17 @@ describe Mixpanel::Consumer do
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
-    it 'should raise server error due to a json error' do
-      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '{'})
-      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not write to Mixpanel, server responded with 200/)
+    it 'should raise server error if response body is empty' do
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => ''})
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not interpret Mixpanel server response: ''/)
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
-    it 'should raise server error when response does not contain key status' do
+    it 'should raise server error when verbose is disabled' do
       # when verbose is disabled, 'verbose' => '1' is ignored, and the response is just 0 even on success
       stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '0'})
-      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not read 'status' key from response, with error/)
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not interpret Mixpanel server response: '0'/)
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -54,6 +54,13 @@ describe Mixpanel::Consumer do
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
 
+    it 'should raise server error when response does not contain key status' do
+      # when verbose is disabled, 'verbose' => '1' is ignored, and the response is just 0 even on success
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '0'})
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not read 'status' key from response, with error/)
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+    end
   end
 
   context 'raw consumer' do

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -46,6 +46,14 @@ describe Mixpanel::Consumer do
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
         with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
     end
+
+    it 'should raise server error due to a json error' do
+      stub_request(:any, 'https://api.mixpanel.com/track').to_return({:status => 200, :body => '{'})
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.to raise_exception(Mixpanel::ServerError, /Could not write to Mixpanel, server responded with 200/)
+      expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track').
+        with(:body => {'data' => 'IlRFU1QgRVZFTlQgTUVTU0FHRSI=', 'verbose' => '1' })
+    end
+
   end
 
   context 'raw consumer' do


### PR DESCRIPTION
Building off of @Zelnox's work in #71 as well as @buger's issue #73.  Catch json errors when parsing the response body and raise an error indicating that we cannot interpret response.