### PR TITLE
Documentation: Ensure token is passed to `Mixpanel::Tracker.new`

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -13,7 +13,7 @@ updates to \Mixpanel from your ruby applications.
 
     require 'mixpanel-ruby'
 
-    tracker = Mixpanel::Tracker.new(YOUR_TOKEN)
+    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
 
     # Track an event on behalf of user "User1"
     tracker.track('User1', 'A Mixpanel Event')

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -44,7 +44,7 @@ module Mixpanel
   # either by passing in an argument with a #send! method when you construct
   # the tracker, or just passing a block to Mixpanel::Tracker.new
   #
-  #    tracker = Mixpanel::Tracker.new(MY_TOKEN) do |type, message|
+  #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN) do |type, message|
   #        # type will be one of :event, :profile_update or :import
   #        @kestrel.set(ANALYTICS_QUEUE, [type, message].to_json)
   #    end
@@ -157,7 +157,7 @@ module Mixpanel
   #
   #    buffered_consumer = Mixpanel::BufferedConsumer.new
   #    begin
-  #        buffered_tracker = Mixpanel::Tracker.new(YOUR_TOKEN) do |type, message|
+  #        buffered_tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN) do |type, message|
   #            buffered_consumer.send!(type, message)
   #        end
   #        # Do some tracking here

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -8,7 +8,7 @@ module Mixpanel
   # is a subclass of this class, and the best way to
   # track events is to instantiate a Mixpanel::Tracker
   #
-  #     tracker = Mixpanel::Tracker.new # Has all of the methods of Mixpanel::Event
+  #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN) # Has all of the methods of Mixpanel::Event
   #     tracker.track(...)
   #
   class Events
@@ -18,7 +18,7 @@ module Mixpanel
     # is to use Mixpanel::Tracker
     #
     #     # tracker has all of the methods of Mixpanel::Events
-    #     tracker = Mixpanel::Tracker.new(...)
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     def initialize(token, &block)
       @token = token
@@ -37,7 +37,7 @@ module Mixpanel
     # describing that event. Properties are provided as a Hash with
     # string keys and strings, numbers or booleans as values.
     #
-    #     tracker = Mixpanel::Tracker.new
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #     # Track that user "12345"'s credit card was declined
     #     tracker.track("12345", "Credit Card Declined")
@@ -83,7 +83,7 @@ module Mixpanel
     # we pass the time of the method call as the time the event occured, if you
     # wish to override this pass a timestamp in the properties hash.
     #
-    #     tracker = Mixpanel::Tracker.new
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #     # Track that user "12345"'s credit card was declined
     #     tracker.import("API_KEY", "12345", "Credit Card Declined")

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -17,7 +17,7 @@ module Mixpanel
     # You likely won't need to instantiate instances of Mixpanel::People
     # directly. The best way to get an instance of Mixpanel::People is
     #
-    #     tracker = Mixpanel::Tracker.new(...)
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #     tracker.people # An instance of Mixpanel::People
     #
     def initialize(token, &block)
@@ -35,7 +35,7 @@ module Mixpanel
     # keys, and values that are strings, numbers, booleans, or
     # DateTimes
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #    # Sets properties on profile with id "1234"
     #    tracker.people.set("1234", {
     #        'company' => 'Acme',
@@ -61,7 +61,7 @@ module Mixpanel
     # in the profile. That means you can call set_once many times
     # without changing an original value.
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #    tracker.people.set_once("12345", {
     #        'First Login Date': DateTime.now
     #    });
@@ -83,7 +83,7 @@ module Mixpanel
     # property. If no property exists with a given name, the value
     # will be added to zero.
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #    tracker.people.increment("12345", {
     #        'Coins Spent' => 7,
     #        'Coins Earned' => -7, # Use a negative number to subtract
@@ -104,7 +104,7 @@ module Mixpanel
     # by one. Calling #plus_one(distinct_id, property_name) is the same as calling
     # #increment(distinct_id, {property_name => 1})
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #    tracker.people.plus_one("12345", "Albums Released")
     #
     def plus_one(distinct_id, property_name, ip=nil, optional_params={})
@@ -115,7 +115,7 @@ module Mixpanel
     # If the given properties don't exist, a new list-valued
     # property will be created.
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #    tracker.people.append("12345", {
     #        'Login Dates' => DateTime.now,
     #        'Alter Ego Names' => 'Ziggy Stardust'
@@ -138,7 +138,7 @@ module Mixpanel
     # property. After a union, every element in the list associated
     # with a property will be unique.
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #    tracker.people.union("12345", {
     #        'Levels Completed' => ['Suffragette City']
     #    });
@@ -156,7 +156,7 @@ module Mixpanel
 
     # Removes properties and their values from a profile.
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #    # removes a single property and its value from a profile
     #    tracker.people.unset("12345", "Overdue Since")
@@ -178,7 +178,7 @@ module Mixpanel
     # Records a payment to you to a profile. Charges recorded with
     # #track_charge will appear in the \Mixpanel revenue report.
     #
-    #    tracker = Mixpanel::Tracker.new
+    #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #    # records a charge of $25.32 from user 12345
     #    tracker.people.track_charge("12345", 25.32)

--- a/lib/mixpanel-ruby/tracker.rb
+++ b/lib/mixpanel-ruby/tracker.rb
@@ -55,7 +55,7 @@ module Mixpanel
     # as a Hash with string keys and strings, numbers or booleans as
     # values.
     #
-    #     tracker = Mixpanel::Tracker.new
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #     # Track that user "12345"'s credit card was declined
     #     tracker.track("12345", "Credit Card Declined")
@@ -79,7 +79,7 @@ module Mixpanel
     # as a Hash with string keys and strings, numbers or booleans as
     # values.
     #
-    #     tracker = Mixpanel::Tracker.new
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #     # Import event that user "12345"'s credit card was declined
     #     tracker.import("API_KEY", "12345", "Credit Card Declined", {
@@ -140,7 +140,7 @@ module Mixpanel
     # strings, numbers or booleans as values. For more information, please see:
     # https://mixpanel.com/docs/api-documentation/pixel-based-event-tracking
     #
-    #     tracker = Mixpanel::Tracker.new
+    #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
     #
     #     # generate pixel tracking url in order to track that user
     #     # "12345"'s credit card was declined


### PR DESCRIPTION
While looking at the docs here: http://mixpanel.github.io/mixpanel-ruby/Mixpanel/Tracker.html, I noticed that several of the instances of `Mixpanel::Tracker.new` don't include the required token parameter, which confused me -- so here's a fix!

I also somewhat presumptuously normalized the use of the token string in the docs to `YOUR_MIXPANEL_TOKEN`. Hope that's cool...

:heart: 