### PR TITLE
Added an error handler injection to enable custom error behaviour

### DIFF
--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -20,8 +20,9 @@ module Mixpanel
     #     # tracker has all of the methods of Mixpanel::Events
     #     tracker = Mixpanel::Tracker.new(...)
     #
-    def initialize(token, &block)
+    def initialize(token, error_handler = ->(e) {}, &block)
       @token = token
+      @error_handler = error_handler
 
       if block
         @sink = block
@@ -68,7 +69,8 @@ module Mixpanel
       ret = true
       begin
         @sink.call(:event, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 
@@ -118,7 +120,8 @@ module Mixpanel
       ret = true
       begin
         @sink.call(:import, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -20,8 +20,9 @@ module Mixpanel
     #     tracker = Mixpanel::Tracker.new(...)
     #     tracker.people # An instance of Mixpanel::People
     #
-    def initialize(token, &block)
+    def initialize(token, error_handler = ->(e) {}, &block)
       @token = token
+      @error_handler = error_handler
 
       if block
         @sink = block
@@ -228,7 +229,8 @@ module Mixpanel
       ret = true
       begin
         @sink.call(:profile_update, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/tracker.rb
+++ b/lib/mixpanel-ruby/tracker.rb
@@ -42,10 +42,10 @@ module Mixpanel
     # If a block is provided, it is passed a type (one of :event or :profile_update)
     # and a string message. This same format is accepted by Mixpanel::Consumer#send!
     # and Mixpanel::BufferedConsumer#send!
-    def initialize(token, &block)
-      super(token, &block)
+    def initialize(token, error_handler = ->(e) {}, &block)
+      super(token, error_handler, &block)
       @token = token
-      @people = People.new(token, &block)
+      @people = People.new(token, error_handler, &block)
     end
 
     # A call to #track is a report that an event has occurred.  #track
@@ -125,7 +125,8 @@ module Mixpanel
       ret = true
       begin
         consumer.send!(:event, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -91,7 +91,7 @@ describe Mixpanel::Events do
 
     context 'when providing a custom error handler' do
 
-      custom_error_handler = ->(e) { raise e }
+      let(:custom_error_handler) { double("Error hander") }
 
       before(:each) do
         @events = Mixpanel::Events.new('TEST TOKEN', custom_error_handler) do |type, message|
@@ -100,11 +100,9 @@ describe Mixpanel::Events do
       end
 
       it "should use the custom error_handler" do
+        expect(custom_error_handler).to receive(:call)
 
-        expect{
-          @events.track('TEST ID', 'Test Event', {})
-        }.to raise_error
-
+        @events.track('TEST ID', 'Test Event', {})
       end
 
     end

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -72,4 +72,43 @@ describe Mixpanel::Events do
         }
     } ]])
   end
+
+  context 'error handling' do
+
+    before(:each) do
+      @events = Mixpanel::Events.new('TEST TOKEN') do |type, message|
+        raise Mixpanel::MixpanelError
+      end
+    end
+
+    it "should silence the exception and return false" do
+
+      result = @events.track('TEST ID', 'Test Event', {})
+
+      expect(result).to be_falsy
+
+    end
+
+    context 'when providing a custom error handler' do
+
+      custom_error_handler = ->(e) { raise e }
+
+      before(:each) do
+        @events = Mixpanel::Events.new('TEST TOKEN', custom_error_handler) do |type, message|
+          raise Mixpanel::MixpanelError
+        end
+      end
+
+      it "should use the custom error_handler" do
+
+        expect{
+          @events.track('TEST ID', 'Test Event', {})
+        }.to raise_error
+
+      end
+
+    end
+
+  end
+
 end

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -218,7 +218,7 @@ describe Mixpanel::People do
 
     context 'when providing a custom error handler' do
 
-      custom_error_handler = ->(e) { raise e }
+      let(:custom_error_handler) { double("Error hander") }
 
       before(:each) do
         @people = Mixpanel::People.new('TEST TOKEN', custom_error_handler) do |type, message|
@@ -227,11 +227,9 @@ describe Mixpanel::People do
       end
 
       it "should use the custom error_handler" do
+        expect(custom_error_handler).to receive(:call)
 
-        expect{
-          @people.set("TEST ID", {})
-        }.to raise_error
-
+        @people.set("TEST ID", {})
       end
 
     end

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -200,4 +200,42 @@ describe Mixpanel::People do
     }]])
   end
 
+  context 'error handling' do
+
+    before(:each) do
+      @people = Mixpanel::People.new('TEST TOKEN') do |type, message|
+        raise Mixpanel::MixpanelError
+      end
+    end
+
+    it "should silence the exception and return false" do
+
+      result = @people.set("TEST ID", {})
+
+      expect(result).to be_falsy
+
+    end
+
+    context 'when providing a custom error handler' do
+
+      custom_error_handler = ->(e) { raise e }
+
+      before(:each) do
+        @people = Mixpanel::People.new('TEST TOKEN', custom_error_handler) do |type, message|
+          raise Mixpanel::MixpanelError
+        end
+      end
+
+      it "should use the custom error_handler" do
+
+        expect{
+          @people.set("TEST ID", {})
+        }.to raise_error
+
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Hey guys,

we recently updated mixpanel-ruby from v1.4.0 to 2.1.0 and this morning we discovered that the errors raised by the gem had been silenced in #66

I totally understand the arguments in favor of silencing those errors but in certain cases it could be helpfull for the developer to decide on the strategy to use.

This morning, for example, for no apparent reason the gem wasn't sending any data to Mixpanel in development environment (the solution was to reboot our DSL box ...). The gem didn't provide any usable intel to help us fix this issue :/

This is why i'm suggesting to add the possibility for the developer to inject his own error handling strategy.

My PR is pretty simple (the error silencing feature wasn't tested in the specs so I had to add a few specs).
I have a concern regarding code duplication with the default `error_handler = ->(e) {}` in the 3 initializers.

What do you think ?