### PR TITLE
less strict ssl and open timeouts

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -134,10 +134,10 @@ module Mixpanel
 
       client = Net::HTTP.new(uri.host, uri.port)
       client.use_ssl = true
-      client.open_timeout = 2
+      client.open_timeout = 10
       client.continue_timeout = 10
       client.read_timeout = 10
-      client.ssl_timeout = 2
+      client.ssl_timeout = 10
 
       Mixpanel.with_http(client)
 


### PR DESCRIPTION
Addresses #63.  We want to have base timeouts that are less strict, as to not cause timeout errors for customers far away from our data centers.  Of course if you want your timeouts to be more strict or more lenient you can always override the default behavior:

```ruby
Mixpanel.config_http do |http|
  http.open_timeout = 2
  http.open_timeout = 2
end
```