### PR TITLE
Minor mixpanel error handler

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -1,6 +1,6 @@
 require 'base64'
-require 'net/https'
 require 'json'
+require 'net/https'
 
 module Mixpanel
   @@init_http = nil

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -3,15 +3,6 @@ require 'net/https'
 require 'json'
 
 module Mixpanel
-  class MixpanelError < StandardError
-  end
-  
-  class ConnectionError < MixpanelError
-  end
-  
-  class ServerError < MixpanelError
-  end
-
   @@init_http = nil
 
   # This method exists for backwards compatibility. The preferred

--- a/lib/mixpanel-ruby/error.rb
+++ b/lib/mixpanel-ruby/error.rb
@@ -16,7 +16,7 @@ module Mixpanel
 
   # The default behavior of the gem is to silence all errors
   # thrown in the consumer.  If you wish to handle MixpanelErrors
-  # your self you should pass a class that extends ErrorHandler to
+  # yourself you should pass a class that extends ErrorHandler to
   # the Tracker on initialize:
   #
   #    require 'logger'

--- a/lib/mixpanel-ruby/error.rb
+++ b/lib/mixpanel-ruby/error.rb
@@ -1,0 +1,45 @@
+module Mixpanel
+
+  # Mixpanel specific errors that are thrown in the gem.
+  # In the default consumer we catch all errors and raise
+  # Mixpanel specific errors that can be handled in a custom
+  # Error handler.
+  class MixpanelError < StandardError
+  end
+  
+  class ConnectionError < MixpanelError
+  end
+  
+  class ServerError < MixpanelError
+  end
+
+
+  # The default behavior of the gem is to silence all errors
+  # thrown in the consumer.  If you wish to handle MixpanelErrors
+  # your self you should pass a class that extends ErrorHandler to
+  # the Tracker on initialize:
+  #
+  #    require 'logger'
+  #
+  #    class MyErrorHandler < Mixpanel::ErrorHandler
+  #
+  #      def initialize
+  #        @logger = Logger.new('mylogfile.log')
+  #        @logger.level = Logger::ERROR
+  #      end
+  #    
+  #      def handle(error)
+  #        logger.error "#{error.inspect}\n Backtrace: #{error.backtrace}"
+  #       end
+  #
+  #     end
+  #
+  #    my_error_handler = MyErrorHandler.new
+  #    tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN, my_error_handler)
+  class ErrorHandler
+
+    def handle(error)
+      # Override this method to customize error handling within mixpanel-ruby        
+    end
+  end
+end

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -1,4 +1,5 @@
 require 'mixpanel-ruby/consumer'
+require 'mixpanel-ruby/error'
 require 'time'
 
 module Mixpanel
@@ -12,6 +13,7 @@ module Mixpanel
   #     tracker.track(...)
   #
   class Events
+    @error_handler = ErrorHandler.new
 
     # You likely won't need to instantiate an instance of
     # Mixpanel::Events directly. The best way to get an instance
@@ -20,9 +22,9 @@ module Mixpanel
     #     # tracker has all of the methods of Mixpanel::Events
     #     tracker = Mixpanel::Tracker.new(...)
     #
-    def initialize(token, error_handler = ->(e) {}, &block)
+    def initialize(token, error_handler=nil, &block)
       @token = token
-      @error_handler = error_handler
+      @error_handler = error_handler if error_handler
 
       if block
         @sink = block
@@ -70,7 +72,7 @@ module Mixpanel
       begin
         @sink.call(:event, message.to_json)
       rescue MixpanelError => e
-        @error_handler.call(e)
+        @error_handler.handle(e)
         ret = false
       end
 
@@ -121,7 +123,7 @@ module Mixpanel
       begin
         @sink.call(:import, message.to_json)
       rescue MixpanelError => e
-        @error_handler.call(e)
+        @error_handler.hnadle(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -14,7 +14,6 @@ module Mixpanel
   #     tracker.track(...)
   #
   class Events
-    @error_handler = ErrorHandler.new
 
     # You likely won't need to instantiate an instance of
     # Mixpanel::Events directly. The best way to get an instance
@@ -25,7 +24,7 @@ module Mixpanel
     #
     def initialize(token, error_handler=nil, &block)
       @token = token
-      @error_handler = error_handler if error_handler
+      @error_handler = error_handler || ErrorHandler.new
 
       if block
         @sink = block
@@ -124,7 +123,7 @@ module Mixpanel
       begin
         @sink.call(:import, message.to_json)
       rescue MixpanelError => e
-        @error_handler.hadle(e)
+        @error_handler.handle(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -124,8 +124,7 @@ module Mixpanel
       begin
         @sink.call(:import, message.to_json)
       rescue MixpanelError => e
-        puts 'hi'
-        @error_handler.hnadle(e)
+        @error_handler.hadle(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -123,6 +123,7 @@ module Mixpanel
       begin
         @sink.call(:import, message.to_json)
       rescue MixpanelError => e
+        puts 'hi'
         @error_handler.hnadle(e)
         ret = false
       end

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -1,6 +1,7 @@
+require 'time'
+
 require 'mixpanel-ruby/consumer'
 require 'mixpanel-ruby/error'
-require 'time'
 
 module Mixpanel
 

--- a/lib/mixpanel-ruby/events.rb
+++ b/lib/mixpanel-ruby/events.rb
@@ -20,8 +20,9 @@ module Mixpanel
     #     # tracker has all of the methods of Mixpanel::Events
     #     tracker = Mixpanel::Tracker.new(...)
     #
-    def initialize(token, &block)
+    def initialize(token, error_handler = ->(e) {}, &block)
       @token = token
+      @error_handler = error_handler
 
       if block
         @sink = block
@@ -68,7 +69,8 @@ module Mixpanel
       ret = true
       begin
         @sink.call(:event, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 
@@ -118,7 +120,8 @@ module Mixpanel
       ret = true
       begin
         @sink.call(:import, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -1,7 +1,9 @@
-require 'mixpanel-ruby/consumer'
-require 'json'
 require 'date'
+require 'json'
 require 'time'
+
+require 'mixpanel-ruby/consumer'
+require 'mixpanel-ruby/error'
 
 module Mixpanel
 

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -20,8 +20,9 @@ module Mixpanel
     #     tracker = Mixpanel::Tracker.new(...)
     #     tracker.people # An instance of Mixpanel::People
     #
-    def initialize(token, &block)
+    def initialize(token, error_handler = ->(e) {}, &block)
       @token = token
+      @error_handler = error_handler
 
       if block
         @sink = block
@@ -228,7 +229,8 @@ module Mixpanel
       ret = true
       begin
         @sink.call(:profile_update, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -13,6 +13,7 @@ module Mixpanel
   #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
   #     tracker.people.set(...) # Or .append(..), or track_charge(...) etc.
   class People
+    @error_handler = ErrorHandler.new
 
     # You likely won't need to instantiate instances of Mixpanel::People
     # directly. The best way to get an instance of Mixpanel::People is
@@ -20,9 +21,9 @@ module Mixpanel
     #     tracker = Mixpanel::Tracker.new(...)
     #     tracker.people # An instance of Mixpanel::People
     #
-    def initialize(token, error_handler = ->(e) {}, &block)
+    def initialize(token, error_handler=nil, &block)
       @token = token
-      @error_handler = error_handler
+      @error_handler = error_handler if error_handler
 
       if block
         @sink = block
@@ -230,7 +231,7 @@ module Mixpanel
       begin
         @sink.call(:profile_update, message.to_json)
       rescue MixpanelError => e
-        @error_handler.call(e)
+        @error_handler.handle(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/people.rb
+++ b/lib/mixpanel-ruby/people.rb
@@ -15,7 +15,6 @@ module Mixpanel
   #     tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN)
   #     tracker.people.set(...) # Or .append(..), or track_charge(...) etc.
   class People
-    @error_handler = ErrorHandler.new
 
     # You likely won't need to instantiate instances of Mixpanel::People
     # directly. The best way to get an instance of Mixpanel::People is
@@ -25,7 +24,7 @@ module Mixpanel
     #
     def initialize(token, error_handler=nil, &block)
       @token = token
-      @error_handler = error_handler if error_handler
+      @error_handler = error_handler || ErrorHandler.new
 
       if block
         @sink = block

--- a/lib/mixpanel-ruby/tracker.rb
+++ b/lib/mixpanel-ruby/tracker.rb
@@ -42,7 +42,7 @@ module Mixpanel
     # If a block is provided, it is passed a type (one of :event or :profile_update)
     # and a string message. This same format is accepted by Mixpanel::Consumer#send!
     # and Mixpanel::BufferedConsumer#send!
-    def initialize(token, error_handler = ->(e) {}, &block)
+    def initialize(token, error_handler=nil, &block)
       super(token, error_handler, &block)
       @token = token
       @people = People.new(token, error_handler, &block)
@@ -126,7 +126,7 @@ module Mixpanel
       begin
         consumer.send!(:event, message.to_json)
       rescue MixpanelError => e
-        @error_handler.call(e)
+        @error_handler.handle(e)
         ret = false
       end
 

--- a/lib/mixpanel-ruby/tracker.rb
+++ b/lib/mixpanel-ruby/tracker.rb
@@ -42,10 +42,10 @@ module Mixpanel
     # If a block is provided, it is passed a type (one of :event or :profile_update)
     # and a string message. This same format is accepted by Mixpanel::Consumer#send!
     # and Mixpanel::BufferedConsumer#send!
-    def initialize(token, &block)
-      super(token, &block)
+    def initialize(token, error_handler = ->(e) {}, &block)
+      super(token, error_handler, &block)
       @token = token
-      @people = People.new(token, &block)
+      @people = People.new(token, error_handler, &block)
     end
 
     # A call to #track is a report that an event has occurred.  #track
@@ -125,7 +125,8 @@ module Mixpanel
       ret = true
       begin
         consumer.send!(:event, message.to_json)
-      rescue MixpanelError
+      rescue MixpanelError => e
+        @error_handler.call(e)
         ret = false
       end
 

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -1,6 +1,7 @@
+require 'base64'
 require 'spec_helper'
 require 'webmock'
-require 'base64'
+
 require 'mixpanel-ruby/consumer'
 
 describe Mixpanel::Consumer do

--- a/spec/mixpanel-ruby/error_spec.rb
+++ b/spec/mixpanel-ruby/error_spec.rb
@@ -31,6 +31,9 @@ describe Mixpanel::ErrorHandler do
 
     @events.track('TEST ID', 'Test Event', {})
     expect(@log).to eq(['Mixpanel::MixpanelError'])
+
+    @events.import('TEST API KEY', 'TEST DISTINCT_ID', 'Test Event')
+    expect(@log).to eq(['Mixpanel::MixpanelError', 'Mixpanel::MixpanelError'])
   end
 
   it "should handle errors with custom error_handler with Mixpanel::People" do

--- a/spec/mixpanel-ruby/error_spec.rb
+++ b/spec/mixpanel-ruby/error_spec.rb
@@ -19,29 +19,58 @@ describe Mixpanel::ErrorHandler do
     expect(error_handler.respond_to?(:handle)).to be true
   end
 
-  before(:each) do
-    @log = []
-    @error_handler = TestErrorHandler.new(@log)
-  end
+  context 'without a customer error_handler' do
 
-  it "should handle errors with custom error_handler" do
-    @events = Mixpanel::Events.new('TEST TOKEN', @error_handler) do |type, message|
-      raise Mixpanel::MixpanelError
+    before(:each) do
+      @tracker = Mixpanel::Tracker.new('TEST TOKEN') do |type, message|
+        raise Mixpanel::MixpanelError
+      end
     end
 
-    @events.track('TEST ID', 'Test Event', {})
-    expect(@log).to eq(['Mixpanel::MixpanelError'])
-
-    @events.import('TEST API KEY', 'TEST DISTINCT_ID', 'Test Event')
-    expect(@log).to eq(['Mixpanel::MixpanelError', 'Mixpanel::MixpanelError'])
-  end
-
-  it "should handle errors with custom error_handler with Mixpanel::People" do
-    @people = Mixpanel::People.new('TEST TOKEN', @error_handler) do |type, message|
-      raise Mixpanel::MixpanelError
+    it "should silence errors in track calls" do
+      expect {
+        expect(@tracker.track('TEST ID', 'Test Event')).to be false
+      }.to_not raise_error
     end
 
-    @people.set('TEST ID', {})
-    expect(@log).to eq(['Mixpanel::MixpanelError'])
+    it "should handle errors in import calls" do
+      expect {
+        expect(@tracker.import('TEST API KEY', 'TEST DISTINCT_ID', 'Test Event')).to be false
+      }.to_not raise_error
+    end
+
+    it "should handle errors in people calls" do
+      expect {
+        expect(@tracker.people.set('TEST ID', {})).to be false
+      }.to_not raise_error
+    end
+
+  end
+
+  context 'with a custom error_handler' do
+
+    before(:each) do
+      @log = []
+      @error_handler = TestErrorHandler.new(@log)
+      @tracker = Mixpanel::Tracker.new('TEST TOKEN', @error_handler) do |type, message|
+        raise Mixpanel::MixpanelError
+      end
+    end
+
+    it "should handle errors in track calls" do
+      @tracker.track('TEST ID', 'Test Event', {})
+      expect(@log).to eq(['Mixpanel::MixpanelError'])
+    end
+
+    it "should handle errors in import calls" do
+      @tracker.import('TEST API KEY', 'TEST DISTINCT_ID', 'Test Event')
+      expect(@log).to eq(['Mixpanel::MixpanelError'])
+    end
+
+    it "should handle errors in people calls" do
+      @tracker.people.set('TEST ID', {})
+      expect(@log).to eq(['Mixpanel::MixpanelError'])
+    end
+
   end
 end

--- a/spec/mixpanel-ruby/error_spec.rb
+++ b/spec/mixpanel-ruby/error_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'mixpanel-ruby/error.rb'
+require 'mixpanel-ruby/events.rb'
+
+class TestErrorHandler < Mixpanel::ErrorHandler
+  def initialize(log)
+    @log = log
+  end
+
+  def handle(error)
+    @log << error.to_s
+  end
+end
+
+describe Mixpanel::ErrorHandler do
+  it "should respond to #handle`" do
+    error_handler = Mixpanel::ErrorHandler.new
+    expect(error_handler.respond_to?(:handle)).to be true
+  end
+
+  before(:each) do
+    @log = []
+    @error_handler = TestErrorHandler.new(@log)
+  end
+
+  it "should handle errors with custom error_handler" do
+    @events = Mixpanel::Events.new('TEST TOKEN', @error_handler) do |type, message|
+      raise Mixpanel::MixpanelError
+    end
+
+    @events.track('TEST ID', 'Test Event', {})
+    expect(@log).to eq(['Mixpanel::MixpanelError'])
+  end
+
+  it "should handle errors with custom error_handler with Mixpanel::People" do
+    @people = Mixpanel::People.new('TEST TOKEN', @error_handler) do |type, message|
+      raise Mixpanel::MixpanelError
+    end
+
+    @people.set('TEST ID', {})
+    expect(@log).to eq(['Mixpanel::MixpanelError'])
+  end
+end

--- a/spec/mixpanel-ruby/error_spec.rb
+++ b/spec/mixpanel-ruby/error_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 require 'mixpanel-ruby/error.rb'
 require 'mixpanel-ruby/events.rb'
 

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -73,40 +73,4 @@ describe Mixpanel::Events do
     } ]])
   end
 
-  context 'error handling' do
-
-    before(:each) do
-      @events = Mixpanel::Events.new('TEST TOKEN') do |type, message|
-        raise Mixpanel::MixpanelError
-      end
-    end
-
-    it "should silence the exception and return false" do
-
-      result = @events.track('TEST ID', 'Test Event', {})
-
-      expect(result).to be_falsy
-
-    end
-
-    context 'when providing a custom error handler' do
-
-      let(:custom_error_handler) { double("Error hander") }
-
-      before(:each) do
-        @events = Mixpanel::Events.new('TEST TOKEN', custom_error_handler) do |type, message|
-          raise Mixpanel::MixpanelError
-        end
-      end
-
-      it "should use the custom error_handler" do
-        expect(custom_error_handler).to receive(:call)
-
-        @events.track('TEST ID', 'Test Event', {})
-      end
-
-    end
-
-  end
-
 end

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -91,7 +91,7 @@ describe Mixpanel::Events do
 
     context 'when providing a custom error handler' do
 
-      custom_error_handler = ->(e) { raise e }
+      let(:custom_error_handler) { double("Error hander") }
 
       before(:each) do
         @events = Mixpanel::Events.new('TEST TOKEN', custom_error_handler) do |type, message|
@@ -100,11 +100,9 @@ describe Mixpanel::Events do
       end
 
       it "should use the custom error_handler" do
+        expect(custom_error_handler).to receive(:call)
 
-        expect{
-          @events.track('TEST ID', 'Test Event', {})
-        }.to raise_error
-
+        @events.track('TEST ID', 'Test Event', {})
       end
 
     end

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
+require 'time'
+
 require 'mixpanel-ruby/events.rb'
 require 'mixpanel-ruby/version.rb'
-require 'time'
 
 describe Mixpanel::Events do
   before(:each) do
@@ -72,5 +73,4 @@ describe Mixpanel::Events do
         }
     } ]])
   end
-
 end

--- a/spec/mixpanel-ruby/events_spec.rb
+++ b/spec/mixpanel-ruby/events_spec.rb
@@ -72,4 +72,43 @@ describe Mixpanel::Events do
         }
     } ]])
   end
+
+  context 'error handling' do
+
+    before(:each) do
+      @events = Mixpanel::Events.new('TEST TOKEN') do |type, message|
+        raise Mixpanel::MixpanelError
+      end
+    end
+
+    it "should silence the exception and return false" do
+
+      result = @events.track('TEST ID', 'Test Event', {})
+
+      expect(result).to be_falsy
+
+    end
+
+    context 'when providing a custom error handler' do
+
+      custom_error_handler = ->(e) { raise e }
+
+      before(:each) do
+        @events = Mixpanel::Events.new('TEST TOKEN', custom_error_handler) do |type, message|
+          raise Mixpanel::MixpanelError
+        end
+      end
+
+      it "should use the custom error_handler" do
+
+        expect{
+          @events.track('TEST ID', 'Test Event', {})
+        }.to raise_error
+
+      end
+
+    end
+
+  end
+
 end

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -200,40 +200,4 @@ describe Mixpanel::People do
     }]])
   end
 
-  context 'error handling' do
-
-    before(:each) do
-      @people = Mixpanel::People.new('TEST TOKEN') do |type, message|
-        raise Mixpanel::MixpanelError
-      end
-    end
-
-    it "should silence the exception and return false" do
-
-      result = @people.set("TEST ID", {})
-
-      expect(result).to be_falsy
-
-    end
-
-    context 'when providing a custom error handler' do
-
-      let(:custom_error_handler) { double("Error hander") }
-
-      before(:each) do
-        @people = Mixpanel::People.new('TEST TOKEN', custom_error_handler) do |type, message|
-          raise Mixpanel::MixpanelError
-        end
-      end
-
-      it "should use the custom error_handler" do
-        expect(custom_error_handler).to receive(:call)
-
-        @people.set("TEST ID", {})
-      end
-
-    end
-
-  end
-
 end

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -218,7 +218,7 @@ describe Mixpanel::People do
 
     context 'when providing a custom error handler' do
 
-      custom_error_handler = ->(e) { raise e }
+      let(:custom_error_handler) { double("Error hander") }
 
       before(:each) do
         @people = Mixpanel::People.new('TEST TOKEN', custom_error_handler) do |type, message|
@@ -227,11 +227,9 @@ describe Mixpanel::People do
       end
 
       it "should use the custom error_handler" do
+        expect(custom_error_handler).to receive(:call)
 
-        expect{
-          @people.set("TEST ID", {})
-        }.to raise_error
-
+        @people.set("TEST ID", {})
       end
 
     end

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 require 'mixpanel-ruby/people'
 
 describe Mixpanel::People do

--- a/spec/mixpanel-ruby/people_spec.rb
+++ b/spec/mixpanel-ruby/people_spec.rb
@@ -200,4 +200,42 @@ describe Mixpanel::People do
     }]])
   end
 
+  context 'error handling' do
+
+    before(:each) do
+      @people = Mixpanel::People.new('TEST TOKEN') do |type, message|
+        raise Mixpanel::MixpanelError
+      end
+    end
+
+    it "should silence the exception and return false" do
+
+      result = @people.set("TEST ID", {})
+
+      expect(result).to be_falsy
+
+    end
+
+    context 'when providing a custom error handler' do
+
+      custom_error_handler = ->(e) { raise e }
+
+      before(:each) do
+        @people = Mixpanel::People.new('TEST TOKEN', custom_error_handler) do |type, message|
+          raise Mixpanel::MixpanelError
+        end
+      end
+
+      it "should use the custom error_handler" do
+
+        expect{
+          @people.set("TEST ID", {})
+        }.to raise_error
+
+      end
+
+    end
+
+  end
+
 end

--- a/spec/mixpanel-ruby/tracker_spec.rb
+++ b/spec/mixpanel-ruby/tracker_spec.rb
@@ -1,8 +1,8 @@
-require 'mixpanel-ruby'
 require 'base64'
-require 'json'
-require 'uri'
 require 'cgi'
+require 'json'
+require 'mixpanel-ruby'
+require 'uri'
 
 describe Mixpanel::Tracker do
   before(:each) do


### PR DESCRIPTION
Standardize an api for custom error handlers.  Inspired by @EtienneDepaulis in #82.  The api is as follows.  To create a custom error handler, extend `Mixpanel::ErrorHandler` and pass an instance of this custom class to `Mixpanel::Tracker` on initialization.  For example:

```ruby
require 'logger'

class MyErrorHandler < Mixpanel::ErrorHandler

  def initialize
    @logger = Logger.new('mylogfile.log')
    @logger.level = Logger::ERROR
  end
    
  def handle(error)
    logger.error "#{error.inspect}\n Backtrace: #{error.backtrace}"
  end
end

my_error_handler = MyErrorHandler.new
tracker = Mixpanel::Tracker.new(YOUR_MIXPANEL_TOKEN, my_error_handler)
```