### PR TITLE
Only use ssl if needed

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -124,7 +124,7 @@ module Mixpanel
       request.set_form_data(form_data)
 
       client = Net::HTTP.new(uri.host, uri.port)
-      client.use_ssl = true
+      client.use_ssl = (uri.scheme == 'https')
       client.open_timeout = 10
       client.continue_timeout = 10
       client.read_timeout = 10

--- a/spec/mixpanel-ruby/consumer_spec.rb
+++ b/spec/mixpanel-ruby/consumer_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 require 'webmock'
 
 require 'mixpanel-ruby/consumer'
+require 'mixpanel-ruby/error'
 
 describe Mixpanel::Consumer do
   before { WebMock.reset! }
@@ -86,6 +87,17 @@ describe Mixpanel::Consumer do
     end
 
     it_behaves_like 'consumer'
+  end
+
+  context 'custom http endpoints' do
+    let(:endpoints) { ["http://example.com/track", nil, nil] }
+    subject { Mixpanel::Consumer.new(*endpoints) }
+
+    it 'should not use ssl' do
+      stub_request(:any, endpoints.first).to_return({:body => '{"status": 1, "error": null}'})
+      expect { subject.send!(:event, {'data' => 'TEST EVENT MESSAGE'}.to_json) }.not_to raise_error # WebMock::NetConnectNotAllowedError
+      expect(WebMock).to have_requested(:post, endpoints.first)
+    end
   end
 
 end


### PR DESCRIPTION
Currently ssl is hardcoded in Consumer if if a custom http endpoint has been set. Simple fix by looking at the uri scheme.