### PR TITLE
Relaxed Ruby version requirement

### DIFF
--- a/mixpanel-ruby.gemspec
+++ b/mixpanel-ruby.gemspec
@@ -12,7 +12,7 @@ spec = Gem::Specification.new do |spec|
   spec.homepage = 'https://mixpanel.com/help/reference/ruby'
   spec.license = 'Apache License 2.0'
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency 'activesupport', '~> 4.0'
   spec.add_development_dependency 'rake', '~> 0'


### PR DESCRIPTION
Is there a reason why the minimum required Ruby version is 2.0.0? If not, I'd be great to be able to back off of that restriction a bit.
