### PR TITLE
Fix import to use a block to configure the http post

### DIFF
--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -4,6 +4,7 @@ require 'net/https'
 
 module Mixpanel
   @@init_http = nil
+  @@init_http_request = nil
 
   # This method exists for backwards compatibility. The preferred
   # way to customize or configure the HTTP library of a consumer
@@ -24,6 +25,20 @@ module Mixpanel
   # to configure their connections
   def self.config_http(&block)
     @@init_http = block
+  end
+
+  # This method exists as a doorway to configure the http request object,
+  # necessary to use the import method, which is dependant on
+  # your API SECRET in basic_auth
+  #
+  #    Mixpanel.config_http_request do |http_request|
+  #      http_request.basic_auth "'#{ENV['MIXPANEL_API_SECRET']}'", ''
+  #    end
+  #
+  # \Mixpanel Consumer and BufferedConsumer will call your block
+  # to configure the http request
+  def self.config_http_request(&block)
+    @@init_http_request = block
   end
 
   # A Consumer receives messages from a Mixpanel::Tracker, and
@@ -121,6 +136,7 @@ module Mixpanel
     def request(endpoint, form_data)
       uri = URI(endpoint)
       request = Net::HTTP::Post.new(uri.request_uri)
+      Mixpanel.with_http_request(request)
       request.set_form_data(form_data)
 
       client = Net::HTTP.new(uri.host, uri.port)
@@ -238,6 +254,12 @@ module Mixpanel
   def self.with_http(http)
     if @@init_http
       @@init_http.call(http)
+    end
+  end
+
+  def self.with_http_request(http_request)
+    if @@init_http_request
+      @@init_http_request.call(http_request)
     end
   end
 end


### PR DESCRIPTION
For discussion, no tests written as yet - the branch is working for my purposes presently

### Background
Import is broken. https://github.com/mixpanel/mixpanel-ruby/issues/106

The MixPanel import api requires the API SECRET to be passed in basic authentication

This PR adds a configuration block to the HTTP Post object, so basic_auth can be configured through a block

in host app `config/initializers/mixpanel.rb`
```
Mixpanel.config_http_request do |http_request|
  http_request.basic_auth "#{ENV['MIXPANEL_API_SECRET']}", ''
end
```