### PR TITLE
Clear submitted slices during BufferedConsumer#flush

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -49,6 +49,9 @@ In particular, for Rails apps, the following projects are currently actively mai
 
 == Changes
 
+== 2.2.1
+* Fix buffer clearing on partially successful writes in BufferedConsumer.
+
 == 2.2.0
 * Add Mixpanel::ErrorHandler to simplify custom error handling.
 * Modify Mixpanel::People#fix_property_dates to handle ActiveSupport::TimeWithZone.

--- a/lib/mixpanel-ruby/consumer.rb
+++ b/lib/mixpanel-ruby/consumer.rb
@@ -230,7 +230,7 @@ module Mixpanel
         @buffers[type].each_slice(@max_length) do |chunk|
           data = chunk.map {|message| JSON.load(message)['data'] }
           @sink.call(type, {'data' => data}.to_json)
-          sent_messages += @max_length
+          sent_messages += chunk.length
         end
       rescue
         @buffers[type].slice!(0, sent_messages)

--- a/lib/mixpanel-ruby/version.rb
+++ b/lib/mixpanel-ruby/version.rb
@@ -1,3 +1,3 @@
 module Mixpanel
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
We discovered a bug where BufferedConsumer can cause duplicate messages to be sent to Mixpanel in the event of intermittent network failures. This fixes the duplicate submissions.