### PR TITLE
fix(analytics): distinguish fallback reasons + forward backend error message (SDK-79, SDK-83)

### DIFF
--- a/lib/mixpanel-ruby/flags/local_flags_provider.rb
+++ b/lib/mixpanel-ruby/flags/local_flags_provider.rb
@@ -102,11 +102,11 @@ module Mixpanel
       def get_variant(flag_key, fallback_variant, context, report_exposure: true)
         flag = @flag_definitions[flag_key]
 
-        return fallback_variant.as_fallback(FallbackReason::FLAG_NOT_FOUND) unless flag
+        return fallback_variant.as_fallback(FallbackReason.flag_not_found) unless flag
 
         context_key = flag['context']
         unless context.key?(context_key) || context.key?(context_key.to_sym)
-          return fallback_variant.as_fallback(FallbackReason::MISSING_CONTEXT_KEY)
+          return fallback_variant.as_fallback(FallbackReason.missing_context_key(context_key))
         end
 
         context_value = context[context_key] || context[context_key.to_sym]
@@ -118,7 +118,7 @@ module Mixpanel
           selected_variant = get_assigned_variant(flag, context_value, flag_key, rollout) if rollout
         end
 
-        return fallback_variant.as_fallback(FallbackReason::NO_ROLLOUT_MATCH) unless selected_variant
+        return fallback_variant.as_fallback(FallbackReason.no_rollout_match) unless selected_variant
 
         track_exposure_event(flag_key, selected_variant, context) if report_exposure
         selected_variant.with_source(VariantSource::LOCAL)

--- a/lib/mixpanel-ruby/flags/local_flags_provider.rb
+++ b/lib/mixpanel-ruby/flags/local_flags_provider.rb
@@ -102,11 +102,11 @@ module Mixpanel
       def get_variant(flag_key, fallback_variant, context, report_exposure: true)
         flag = @flag_definitions[flag_key]
 
-        return fallback_variant unless flag
+        return fallback_variant.as_fallback(FallbackReason::FLAG_NOT_FOUND) unless flag
 
         context_key = flag['context']
         unless context.key?(context_key) || context.key?(context_key.to_sym)
-          return fallback_variant
+          return fallback_variant.as_fallback(FallbackReason::MISSING_CONTEXT_KEY)
         end
 
         context_value = context[context_key] || context[context_key.to_sym]
@@ -118,10 +118,10 @@ module Mixpanel
           selected_variant = get_assigned_variant(flag, context_value, flag_key, rollout) if rollout
         end
 
-        return fallback_variant unless selected_variant
+        return fallback_variant.as_fallback(FallbackReason::NO_ROLLOUT_MATCH) unless selected_variant
 
         track_exposure_event(flag_key, selected_variant, context) if report_exposure
-        selected_variant
+        selected_variant.with_source(VariantSource::LOCAL)
       end
 
       # Get all variants for user context
@@ -130,10 +130,11 @@ module Mixpanel
       # @return [Hash] Map of flag_key => SelectedVariant
       def get_all_variants(context)
         variants = {}
+        fallback = SelectedVariant.new(variant_value: nil)
 
         @flag_definitions.each_key do |flag_key|
-          variant = get_variant(flag_key, nil, context, report_exposure: false)
-          variants[flag_key] = variant if variant
+          variant = get_variant(flag_key, fallback, context, report_exposure: false)
+          variants[flag_key] = variant if variant.variant_source == VariantSource::LOCAL
         end
 
         variants

--- a/lib/mixpanel-ruby/flags/remote_flags_provider.rb
+++ b/lib/mixpanel-ruby/flags/remote_flags_provider.rb
@@ -59,13 +59,18 @@ module Mixpanel
         flags = response['flags'] || {}
         selected_variant_data = flags[flag_key]
 
-        return fallback_variant unless selected_variant_data
+        # The /flags endpoint only returns variants the user is enrolled in,
+        # so a missing key could mean the flag doesn't exist OR the user
+        # isn't in any rollout. The remote SDK can't tell them apart without
+        # server-side help — surface as FLAG_NOT_FOUND for now.
+        return fallback_variant.as_fallback(FallbackReason::FLAG_NOT_FOUND) unless selected_variant_data
 
         selected_variant = SelectedVariant.new(
           variant_key: selected_variant_data['variant_key'],
           variant_value: selected_variant_data['variant_value'],
           experiment_id: selected_variant_data['experiment_id'],
-          is_experiment_active: selected_variant_data['is_experiment_active']
+          is_experiment_active: selected_variant_data['is_experiment_active'],
+          variant_source: VariantSource::REMOTE
         )
 
         track_exposure_event(flag_key, selected_variant, context, latency_ms) if report_exposure
@@ -73,7 +78,7 @@ module Mixpanel
         return selected_variant
       rescue MixpanelError => e
         @error_handler.handle(e)
-        return fallback_variant
+        return fallback_variant.as_fallback(FallbackReason::BACKEND_ERROR)
       end
 
       # Check if flag is enabled (for boolean flags)
@@ -104,7 +109,8 @@ module Mixpanel
             variant_key: variant_data['variant_key'],
             variant_value: variant_data['variant_value'],
             experiment_id: variant_data['experiment_id'],
-            is_experiment_active: variant_data['is_experiment_active']
+            is_experiment_active: variant_data['is_experiment_active'],
+            variant_source: VariantSource::REMOTE
           )
         end
 

--- a/lib/mixpanel-ruby/flags/remote_flags_provider.rb
+++ b/lib/mixpanel-ruby/flags/remote_flags_provider.rb
@@ -63,7 +63,7 @@ module Mixpanel
         # so a missing key could mean the flag doesn't exist OR the user
         # isn't in any rollout. The remote SDK can't tell them apart without
         # server-side help — surface as FLAG_NOT_FOUND for now.
-        return fallback_variant.as_fallback(FallbackReason::FLAG_NOT_FOUND) unless selected_variant_data
+        return fallback_variant.as_fallback(FallbackReason.flag_not_found) unless selected_variant_data
 
         selected_variant = SelectedVariant.new(
           variant_key: selected_variant_data['variant_key'],
@@ -78,7 +78,12 @@ module Mixpanel
         return selected_variant
       rescue MixpanelError => e
         @error_handler.handle(e)
-        return fallback_variant.as_fallback(FallbackReason::BACKEND_ERROR)
+        # Attach the backend's message so the OpenFeature wrapper can forward
+        # it into ResolutionDetails#error_message — without this the caller
+        # sees a bare GENERAL error and has to dig through logs to find out
+        # the backend rejected the request (e.g. "distinct_id must be
+        # provided in evalContext as a string"). SDK-83.
+        return fallback_variant.as_fallback(FallbackReason.backend_error(e.message))
       end
 
       # Check if flag is enabled (for boolean flags)

--- a/lib/mixpanel-ruby/flags/types.rb
+++ b/lib/mixpanel-ruby/flags/types.rb
@@ -1,34 +1,81 @@
 module Mixpanel
   module Flags
+    # Where a SelectedVariant came from. Set by the providers on every returned
+    # variant — coarse-grained (local / remote / fallback). For the specific
+    # reason behind a fallback, see {FallbackReason}.
+    module VariantSource
+      LOCAL    = 'local'.freeze
+      REMOTE   = 'remote'.freeze
+      FALLBACK = 'fallback'.freeze
+    end
+
+    # Why the SDK returned the developer fallback. Only meaningful when
+    # SelectedVariant#variant_source == VariantSource::FALLBACK. Matches the
+    # constant set used by mixpanel-php so the OpenFeature wrapper can map to
+    # the spec-correct error code instead of collapsing every fallback to
+    # FLAG_NOT_FOUND.
+    module FallbackReason
+      FLAG_NOT_FOUND      = 'FLAG_NOT_FOUND'.freeze
+      MISSING_CONTEXT_KEY = 'MISSING_CONTEXT_KEY'.freeze
+      NO_ROLLOUT_MATCH    = 'NO_ROLLOUT_MATCH'.freeze
+      BACKEND_ERROR       = 'BACKEND_ERROR'.freeze
+      NOT_READY           = 'NOT_READY'.freeze
+    end
+
     # Selected variant returned from flag evaluation
     class SelectedVariant
       attr_accessor :variant_key, :variant_value, :experiment_id,
-                    :is_experiment_active, :is_qa_tester
+                    :is_experiment_active, :is_qa_tester,
+                    :variant_source, :fallback_reason
 
-      # @param variant_key [String, nil] The variant key
-      # @param variant_value [Object] The variant value (any type)
-      # @param experiment_id [String, nil] Associated experiment ID
-      # @param is_experiment_active [Boolean, nil] Whether experiment is active
-      # @param is_qa_tester [Boolean, nil] Whether user is a QA tester
       def initialize(variant_key: nil, variant_value: nil, experiment_id: nil,
-                     is_experiment_active: nil, is_qa_tester: nil)
+                     is_experiment_active: nil, is_qa_tester: nil,
+                     variant_source: nil, fallback_reason: nil)
         @variant_key = variant_key
         @variant_value = variant_value
         @experiment_id = experiment_id
         @is_experiment_active = is_experiment_active
         @is_qa_tester = is_qa_tester
+        @variant_source = variant_source
+        @fallback_reason = fallback_reason
+      end
+
+      # Return a copy of this variant tagged with the given source. Clears
+      # fallback_reason — use {#as_fallback} when returning a fallback.
+      def with_source(source)
+        copy_with(variant_source: source, fallback_reason: nil)
+      end
+
+      # Return a copy tagged as a fallback with the given reason.
+      def as_fallback(reason)
+        copy_with(variant_source: VariantSource::FALLBACK, fallback_reason: reason)
       end
 
       # Convert to hash representation
-      # @return [Hash]
       def to_h
         {
           variant_key: @variant_key,
           variant_value: @variant_value,
           experiment_id: @experiment_id,
           is_experiment_active: @is_experiment_active,
-          is_qa_tester: @is_qa_tester
+          is_qa_tester: @is_qa_tester,
+          variant_source: @variant_source,
+          fallback_reason: @fallback_reason
         }.compact
+      end
+
+      private
+
+      def copy_with(variant_source: @variant_source, fallback_reason: @fallback_reason)
+        SelectedVariant.new(
+          variant_key: @variant_key,
+          variant_value: @variant_value,
+          experiment_id: @experiment_id,
+          is_experiment_active: @is_experiment_active,
+          is_qa_tester: @is_qa_tester,
+          variant_source: variant_source,
+          fallback_reason: fallback_reason
+        )
       end
     end
   end

--- a/lib/mixpanel-ruby/flags/types.rb
+++ b/lib/mixpanel-ruby/flags/types.rb
@@ -17,8 +17,12 @@ module Mixpanel
     # backend's response, MISSING_CONTEXT_KEY with the missing attribute);
     # nil otherwise. The OpenFeature wrapper dispatches on kind and forwards
     # message into ResolutionDetails#error_message.
+    #
+    # Note: the wrapper handles PROVIDER_NOT_READY by short-circuiting before
+    # invoking the provider (see flags_ready? check), so there is no :not_ready
+    # kind here — no producer would ever construct it.
     class FallbackReason
-      KINDS = %i[flag_not_found missing_context_key no_rollout_match backend_error not_ready].freeze
+      KINDS = %i[flag_not_found missing_context_key no_rollout_match backend_error].freeze
 
       attr_reader :kind, :message
 
@@ -47,13 +51,11 @@ module Mixpanel
       # singleton; reasons with detail allocate per call.
       def self.flag_not_found;      FLAG_NOT_FOUND;   end
       def self.no_rollout_match;    NO_ROLLOUT_MATCH; end
-      def self.not_ready;           NOT_READY;        end
       def self.missing_context_key(key = nil); new(:missing_context_key, message: key); end
       def self.backend_error(message); new(:backend_error, message: message); end
 
       FLAG_NOT_FOUND   = new(:flag_not_found)
       NO_ROLLOUT_MATCH = new(:no_rollout_match)
-      NOT_READY        = new(:not_ready)
     end
 
     # Selected variant returned from flag evaluation

--- a/lib/mixpanel-ruby/flags/types.rb
+++ b/lib/mixpanel-ruby/flags/types.rb
@@ -10,16 +10,50 @@ module Mixpanel
     end
 
     # Why the SDK returned the developer fallback. Only meaningful when
-    # SelectedVariant#variant_source == VariantSource::FALLBACK. Matches the
-    # constant set used by mixpanel-php so the OpenFeature wrapper can map to
-    # the spec-correct error code instead of collapsing every fallback to
-    # FLAG_NOT_FOUND.
-    module FallbackReason
-      FLAG_NOT_FOUND      = 'FLAG_NOT_FOUND'.freeze
-      MISSING_CONTEXT_KEY = 'MISSING_CONTEXT_KEY'.freeze
-      NO_ROLLOUT_MATCH    = 'NO_ROLLOUT_MATCH'.freeze
-      BACKEND_ERROR       = 'BACKEND_ERROR'.freeze
-      NOT_READY           = 'NOT_READY'.freeze
+    # SelectedVariant#variant_source == VariantSource::FALLBACK.
+    #
+    # `kind` is the discriminator (matches the PHP constant set). `message`
+    # is set on the reasons that carry useful detail (BACKEND_ERROR with the
+    # backend's response, MISSING_CONTEXT_KEY with the missing attribute);
+    # nil otherwise. The OpenFeature wrapper dispatches on kind and forwards
+    # message into ResolutionDetails#error_message.
+    class FallbackReason
+      KINDS = %i[flag_not_found missing_context_key no_rollout_match backend_error not_ready].freeze
+
+      attr_reader :kind, :message
+
+      def initialize(kind, message: nil)
+        raise ArgumentError, "Unknown FallbackReason kind: #{kind.inspect}" unless KINDS.include?(kind)
+
+        @kind = kind
+        @message = message
+        freeze
+      end
+
+      def ==(other)
+        other.is_a?(FallbackReason) && other.kind == @kind && other.message == @message
+      end
+      alias_method :eql?, :==
+
+      def hash
+        [self.class, @kind, @message].hash
+      end
+
+      def to_h
+        { kind: @kind, message: @message }.compact
+      end
+
+      # Factory methods. Reasons without meaningful detail return a frozen
+      # singleton; reasons with detail allocate per call.
+      def self.flag_not_found;      FLAG_NOT_FOUND;   end
+      def self.no_rollout_match;    NO_ROLLOUT_MATCH; end
+      def self.not_ready;           NOT_READY;        end
+      def self.missing_context_key(key = nil); new(:missing_context_key, message: key); end
+      def self.backend_error(message); new(:backend_error, message: message); end
+
+      FLAG_NOT_FOUND   = new(:flag_not_found)
+      NO_ROLLOUT_MATCH = new(:no_rollout_match)
+      NOT_READY        = new(:not_ready)
     end
 
     # Selected variant returned from flag evaluation

--- a/lib/mixpanel-ruby/flags/types.rb
+++ b/lib/mixpanel-ruby/flags/types.rb
@@ -17,10 +17,6 @@ module Mixpanel
     # backend's response, MISSING_CONTEXT_KEY with the missing attribute);
     # nil otherwise. The OpenFeature wrapper dispatches on kind and forwards
     # message into ResolutionDetails#error_message.
-    #
-    # Note: the wrapper handles PROVIDER_NOT_READY by short-circuiting before
-    # invoking the provider (see flags_ready? check), so there is no :not_ready
-    # kind here — no producer would ever construct it.
     class FallbackReason
       KINDS = %i[flag_not_found missing_context_key no_rollout_match backend_error].freeze
 

--- a/openfeature-provider/lib/mixpanel/openfeature/provider.rb
+++ b/openfeature-provider/lib/mixpanel/openfeature/provider.rb
@@ -69,37 +69,42 @@ module Mixpanel
 
         begin
           result = @flags_provider.get_variant(flag_key, fallback, context, report_exposure: true)
-        rescue StandardError
-          return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::GENERAL)
+        rescue StandardError => e
+          return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::GENERAL, e.message)
         end
 
         # variant_source distinguishes local / remote / fallback. When fallback,
         # fallback_reason carries the specific reason (PHP-aligned constants)
         # so we can map each to the spec-correct OpenFeature response instead
-        # of collapsing every fallback to FLAG_NOT_FOUND.
-        case result.fallback_reason
-        when ::Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND
+        # of collapsing every fallback to FLAG_NOT_FOUND. SDK-83: BACKEND_ERROR
+        # also carries the backend message, forwarded as error_message.
+        case result.fallback_reason&.kind
+        when :flag_not_found
           return ::OpenFeature::SDK::Provider::ResolutionDetails.new(
             value: default_value,
             error_code: ::OpenFeature::SDK::Provider::ErrorCode::FLAG_NOT_FOUND,
             reason: ::OpenFeature::SDK::Provider::Reason::DEFAULT
           )
-        when ::Mixpanel::Flags::FallbackReason::MISSING_CONTEXT_KEY
-          return ::OpenFeature::SDK::Provider::ResolutionDetails.new(
-            value: default_value,
-            error_code: ::OpenFeature::SDK::Provider::ErrorCode::TARGETING_KEY_MISSING,
-            reason: ::OpenFeature::SDK::Provider::Reason::ERROR
+        when :missing_context_key
+          return error_result(
+            default_value,
+            ::OpenFeature::SDK::Provider::ErrorCode::TARGETING_KEY_MISSING,
+            result.fallback_reason.message
           )
-        when ::Mixpanel::Flags::FallbackReason::NO_ROLLOUT_MATCH
+        when :no_rollout_match
           # Flag exists, user just didn't match any rollout — per the
           # OpenFeature spec this is `reason: DEFAULT` with no error.
           return ::OpenFeature::SDK::Provider::ResolutionDetails.new(
             value: default_value,
             reason: ::OpenFeature::SDK::Provider::Reason::DEFAULT
           )
-        when ::Mixpanel::Flags::FallbackReason::BACKEND_ERROR
-          return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::GENERAL)
-        when ::Mixpanel::Flags::FallbackReason::NOT_READY
+        when :backend_error
+          return error_result(
+            default_value,
+            ::OpenFeature::SDK::Provider::ErrorCode::GENERAL,
+            result.fallback_reason.message
+          )
+        when :not_ready
           return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::PROVIDER_NOT_READY)
         end
 
@@ -180,10 +185,11 @@ module Mixpanel
         end
       end
 
-      def error_result(default_value, error_code)
+      def error_result(default_value, error_code, error_message = nil)
         ::OpenFeature::SDK::Provider::ResolutionDetails.new(
           value: default_value,
           error_code: error_code,
+          error_message: error_message,
           reason: ::OpenFeature::SDK::Provider::Reason::ERROR
         )
       end

--- a/openfeature-provider/lib/mixpanel/openfeature/provider.rb
+++ b/openfeature-provider/lib/mixpanel/openfeature/provider.rb
@@ -73,12 +73,34 @@ module Mixpanel
           return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::GENERAL)
         end
 
-        if result.equal?(fallback)
+        # variant_source distinguishes local / remote / fallback. When fallback,
+        # fallback_reason carries the specific reason (PHP-aligned constants)
+        # so we can map each to the spec-correct OpenFeature response instead
+        # of collapsing every fallback to FLAG_NOT_FOUND.
+        case result.fallback_reason
+        when ::Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND
           return ::OpenFeature::SDK::Provider::ResolutionDetails.new(
             value: default_value,
             error_code: ::OpenFeature::SDK::Provider::ErrorCode::FLAG_NOT_FOUND,
             reason: ::OpenFeature::SDK::Provider::Reason::DEFAULT
           )
+        when ::Mixpanel::Flags::FallbackReason::MISSING_CONTEXT_KEY
+          return ::OpenFeature::SDK::Provider::ResolutionDetails.new(
+            value: default_value,
+            error_code: ::OpenFeature::SDK::Provider::ErrorCode::TARGETING_KEY_MISSING,
+            reason: ::OpenFeature::SDK::Provider::Reason::ERROR
+          )
+        when ::Mixpanel::Flags::FallbackReason::NO_ROLLOUT_MATCH
+          # Flag exists, user just didn't match any rollout — per the
+          # OpenFeature spec this is `reason: DEFAULT` with no error.
+          return ::OpenFeature::SDK::Provider::ResolutionDetails.new(
+            value: default_value,
+            reason: ::OpenFeature::SDK::Provider::Reason::DEFAULT
+          )
+        when ::Mixpanel::Flags::FallbackReason::BACKEND_ERROR
+          return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::GENERAL)
+        when ::Mixpanel::Flags::FallbackReason::NOT_READY
+          return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::PROVIDER_NOT_READY)
         end
 
         value = result.variant_value

--- a/openfeature-provider/lib/mixpanel/openfeature/provider.rb
+++ b/openfeature-provider/lib/mixpanel/openfeature/provider.rb
@@ -104,9 +104,10 @@ module Mixpanel
             ::OpenFeature::SDK::Provider::ErrorCode::GENERAL,
             result.fallback_reason.message
           )
-        when :not_ready
-          return error_result(default_value, ::OpenFeature::SDK::Provider::ErrorCode::PROVIDER_NOT_READY)
         end
+        # PROVIDER_NOT_READY is handled at the top of resolve via flags_ready?;
+        # no producer constructs a :not_ready FallbackReason, so there's no
+        # dispatch arm for it here.
 
         value = result.variant_value
 

--- a/openfeature-provider/lib/mixpanel/openfeature/provider.rb
+++ b/openfeature-provider/lib/mixpanel/openfeature/provider.rb
@@ -105,9 +105,6 @@ module Mixpanel
             result.fallback_reason.message
           )
         end
-        # PROVIDER_NOT_READY is handled at the top of resolve via flags_ready?;
-        # no producer constructs a :not_ready FallbackReason, so there's no
-        # dispatch arm for it here.
 
         value = result.variant_value
 

--- a/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
+++ b/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
           variant_source: Mixpanel::Flags::VariantSource::LOCAL
         )
       else
-        fallback.as_fallback(Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND)
+        fallback.as_fallback(Mixpanel::Flags::FallbackReason.flag_not_found)
       end
     end
   end
@@ -93,7 +93,7 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
   end
 
   def setup_flag_not_found
-    setup_fallback(Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND)
+    setup_fallback(Mixpanel::Flags::FallbackReason.flag_not_found)
   end
 
   # --- Metadata ---
@@ -318,7 +318,7 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
   # --- NO_ROLLOUT_MATCH (flag exists, no rollout matched) ---
 
   describe 'no rollout match' do
-    before { setup_fallback(Mixpanel::Flags::FallbackReason::NO_ROLLOUT_MATCH) }
+    before { setup_fallback(Mixpanel::Flags::FallbackReason.no_rollout_match) }
 
     it 'returns DEFAULT reason without an error code' do
       result = provider.fetch_boolean_value(flag_key: 'flag', default_value: true)
@@ -338,7 +338,7 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
   # --- MISSING_CONTEXT_KEY ---
 
   describe 'missing context key' do
-    before { setup_fallback(Mixpanel::Flags::FallbackReason::MISSING_CONTEXT_KEY) }
+    before { setup_fallback(Mixpanel::Flags::FallbackReason.missing_context_key('distinct_id')) }
 
     it 'returns TARGETING_KEY_MISSING for boolean' do
       result = provider.fetch_boolean_value(flag_key: 'flag', default_value: false)
@@ -347,31 +347,39 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
       expect(result.reason).to eq('ERROR')
     end
 
-    it 'returns TARGETING_KEY_MISSING for string' do
+    it 'returns TARGETING_KEY_MISSING for string and forwards the missing key as error_message' do
       result = provider.fetch_string_value(flag_key: 'flag', default_value: 'default')
       expect(result.value).to eq('default')
       expect(result.error_code).to eq('TARGETING_KEY_MISSING')
+      expect(result.error_message).to eq('distinct_id')
       expect(result.reason).to eq('ERROR')
     end
   end
 
-  # --- BACKEND_ERROR ---
+  # --- BACKEND_ERROR (SDK-83: forwards the backend's response message) ---
 
   describe 'backend error' do
-    before { setup_fallback(Mixpanel::Flags::FallbackReason::BACKEND_ERROR) }
+    before do
+      setup_fallback(
+        Mixpanel::Flags::FallbackReason.backend_error(
+          'HTTP 400: distinct_id must be provided in evalContext as a string'
+        )
+      )
+    end
 
-    it 'maps to GENERAL' do
+    it 'maps to GENERAL and forwards the backend message as error_message' do
       result = provider.fetch_string_value(flag_key: 'flag', default_value: 'default')
       expect(result.value).to eq('default')
       expect(result.error_code).to eq('GENERAL')
       expect(result.reason).to eq('ERROR')
+      expect(result.error_message).to include('distinct_id must be provided')
     end
   end
 
   # --- NOT_READY ---
 
   describe 'not ready' do
-    before { setup_fallback(Mixpanel::Flags::FallbackReason::NOT_READY) }
+    before { setup_fallback(Mixpanel::Flags::FallbackReason.not_ready) }
 
     it 'maps to PROVIDER_NOT_READY' do
       result = provider.fetch_boolean_value(flag_key: 'flag', default_value: true)

--- a/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
+++ b/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
@@ -75,15 +75,25 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
   def setup_flag(flag_key, value, variant_key: 'variant-key')
     allow(mock_flags).to receive(:get_variant) do |key, fallback, _ctx, **_kwargs|
       if key == flag_key
-        Mixpanel::Flags::SelectedVariant.new(variant_key: variant_key, variant_value: value)
+        Mixpanel::Flags::SelectedVariant.new(
+          variant_key: variant_key,
+          variant_value: value,
+          variant_source: Mixpanel::Flags::VariantSource::LOCAL
+        )
       else
-        fallback
+        fallback.as_fallback(Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND)
       end
     end
   end
 
+  def setup_fallback(reason)
+    allow(mock_flags).to receive(:get_variant) do |_key, fallback, _ctx, **_kwargs|
+      fallback.as_fallback(reason)
+    end
+  end
+
   def setup_flag_not_found
-    allow(mock_flags).to receive(:get_variant) { |_key, fallback, _ctx, **_kwargs| fallback }
+    setup_fallback(Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND)
   end
 
   # --- Metadata ---
@@ -302,6 +312,72 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
       expect(result.value).to eq({ 'default' => true })
       expect(result.error_code).to eq('FLAG_NOT_FOUND')
       expect(result.reason).to eq('DEFAULT')
+    end
+  end
+
+  # --- NO_ROLLOUT_MATCH (flag exists, no rollout matched) ---
+
+  describe 'no rollout match' do
+    before { setup_fallback(Mixpanel::Flags::FallbackReason::NO_ROLLOUT_MATCH) }
+
+    it 'returns DEFAULT reason without an error code' do
+      result = provider.fetch_boolean_value(flag_key: 'flag', default_value: true)
+      expect(result.value).to be true
+      expect(result.reason).to eq('DEFAULT')
+      expect(result.error_code).to be_nil
+    end
+
+    it 'works for strings' do
+      result = provider.fetch_string_value(flag_key: 'flag', default_value: 'default')
+      expect(result.value).to eq('default')
+      expect(result.reason).to eq('DEFAULT')
+      expect(result.error_code).to be_nil
+    end
+  end
+
+  # --- MISSING_CONTEXT_KEY ---
+
+  describe 'missing context key' do
+    before { setup_fallback(Mixpanel::Flags::FallbackReason::MISSING_CONTEXT_KEY) }
+
+    it 'returns TARGETING_KEY_MISSING for boolean' do
+      result = provider.fetch_boolean_value(flag_key: 'flag', default_value: false)
+      expect(result.value).to be false
+      expect(result.error_code).to eq('TARGETING_KEY_MISSING')
+      expect(result.reason).to eq('ERROR')
+    end
+
+    it 'returns TARGETING_KEY_MISSING for string' do
+      result = provider.fetch_string_value(flag_key: 'flag', default_value: 'default')
+      expect(result.value).to eq('default')
+      expect(result.error_code).to eq('TARGETING_KEY_MISSING')
+      expect(result.reason).to eq('ERROR')
+    end
+  end
+
+  # --- BACKEND_ERROR ---
+
+  describe 'backend error' do
+    before { setup_fallback(Mixpanel::Flags::FallbackReason::BACKEND_ERROR) }
+
+    it 'maps to GENERAL' do
+      result = provider.fetch_string_value(flag_key: 'flag', default_value: 'default')
+      expect(result.value).to eq('default')
+      expect(result.error_code).to eq('GENERAL')
+      expect(result.reason).to eq('ERROR')
+    end
+  end
+
+  # --- NOT_READY ---
+
+  describe 'not ready' do
+    before { setup_fallback(Mixpanel::Flags::FallbackReason::NOT_READY) }
+
+    it 'maps to PROVIDER_NOT_READY' do
+      result = provider.fetch_boolean_value(flag_key: 'flag', default_value: true)
+      expect(result.value).to be true
+      expect(result.error_code).to eq('PROVIDER_NOT_READY')
+      expect(result.reason).to eq('ERROR')
     end
   end
 

--- a/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
+++ b/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
@@ -376,11 +376,6 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
     end
   end
 
-  # Not-ready handling is covered by the `provider not ready` describe block
-  # below, which exercises the wrapper's flags_ready? short-circuit. The
-  # provider never stamps a :not_ready fallback reason, so there is no
-  # producer-side dispatch to test here.
-
   # --- PROVIDER_NOT_READY ---
 
   describe 'provider not ready' do

--- a/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
+++ b/openfeature-provider/spec/mixpanel_openfeature_provider_spec.rb
@@ -376,18 +376,10 @@ RSpec.describe Mixpanel::OpenFeature::Provider do
     end
   end
 
-  # --- NOT_READY ---
-
-  describe 'not ready' do
-    before { setup_fallback(Mixpanel::Flags::FallbackReason.not_ready) }
-
-    it 'maps to PROVIDER_NOT_READY' do
-      result = provider.fetch_boolean_value(flag_key: 'flag', default_value: true)
-      expect(result.value).to be true
-      expect(result.error_code).to eq('PROVIDER_NOT_READY')
-      expect(result.reason).to eq('ERROR')
-    end
-  end
+  # Not-ready handling is covered by the `provider not ready` describe block
+  # below, which exercises the wrapper's flags_ready? short-circuit. The
+  # provider never stamps a :not_ready fallback reason, so there is no
+  # producer-side dispatch to test here.
 
   # --- PROVIDER_NOT_READY ---
 

--- a/spec/mixpanel-ruby/flags/local_flags_spec.rb
+++ b/spec/mixpanel-ruby/flags/local_flags_spec.rb
@@ -734,34 +734,36 @@ describe Mixpanel::Flags::LocalFlagsProvider do
       expect(result.variant_key).not_to be_nil
     end
 
-    it 'tags missing flag as FALLBACK / FLAG_NOT_FOUND' do
+    it 'tags missing flag as FALLBACK / flag_not_found' do
       stub_flag_definitions([])
       provider.start_polling_for_definitions!
 
       result = provider.get_variant('missing', fallback, test_context)
       expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
-      expect(result.fallback_reason).to eq(Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND)
+      expect(result.fallback_reason.kind).to eq(:flag_not_found)
+      expect(result.fallback_reason.message).to be_nil
       expect(result.variant_value).to eq('fb')
     end
 
-    it 'tags missing context as FALLBACK / MISSING_CONTEXT_KEY' do
+    it 'tags missing context as FALLBACK / missing_context_key with the missing attribute' do
       flag = create_test_flag(context: 'distinct_id')
       stub_flag_definitions([flag])
       provider.start_polling_for_definitions!
 
       result = provider.get_variant('test_flag', fallback, {})
       expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
-      expect(result.fallback_reason).to eq(Mixpanel::Flags::FallbackReason::MISSING_CONTEXT_KEY)
+      expect(result.fallback_reason.kind).to eq(:missing_context_key)
+      expect(result.fallback_reason.message).to eq('distinct_id')
     end
 
-    it 'tags no-rollout-match as FALLBACK / NO_ROLLOUT_MATCH' do
+    it 'tags no-rollout-match as FALLBACK / no_rollout_match' do
       flag = create_test_flag(rollout_percentage: 0.0)
       stub_flag_definitions([flag])
       provider.start_polling_for_definitions!
 
       result = provider.get_variant('test_flag', fallback, test_context)
       expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
-      expect(result.fallback_reason).to eq(Mixpanel::Flags::FallbackReason::NO_ROLLOUT_MATCH)
+      expect(result.fallback_reason.kind).to eq(:no_rollout_match)
     end
   end
 

--- a/spec/mixpanel-ruby/flags/local_flags_spec.rb
+++ b/spec/mixpanel-ruby/flags/local_flags_spec.rb
@@ -720,6 +720,51 @@ describe Mixpanel::Flags::LocalFlagsProvider do
     end
   end
 
+  describe '#get_variant variant_source / fallback_reason tagging' do
+    let(:fallback) { Mixpanel::Flags::SelectedVariant.new(variant_value: 'fb') }
+
+    it 'tags matched variants as LOCAL with no fallback_reason' do
+      flag = create_test_flag(rollout_percentage: 100.0)
+      stub_flag_definitions([flag])
+      provider.start_polling_for_definitions!
+
+      result = provider.get_variant('test_flag', fallback, test_context)
+      expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::LOCAL)
+      expect(result.fallback_reason).to be_nil
+      expect(result.variant_key).not_to be_nil
+    end
+
+    it 'tags missing flag as FALLBACK / FLAG_NOT_FOUND' do
+      stub_flag_definitions([])
+      provider.start_polling_for_definitions!
+
+      result = provider.get_variant('missing', fallback, test_context)
+      expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
+      expect(result.fallback_reason).to eq(Mixpanel::Flags::FallbackReason::FLAG_NOT_FOUND)
+      expect(result.variant_value).to eq('fb')
+    end
+
+    it 'tags missing context as FALLBACK / MISSING_CONTEXT_KEY' do
+      flag = create_test_flag(context: 'distinct_id')
+      stub_flag_definitions([flag])
+      provider.start_polling_for_definitions!
+
+      result = provider.get_variant('test_flag', fallback, {})
+      expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
+      expect(result.fallback_reason).to eq(Mixpanel::Flags::FallbackReason::MISSING_CONTEXT_KEY)
+    end
+
+    it 'tags no-rollout-match as FALLBACK / NO_ROLLOUT_MATCH' do
+      flag = create_test_flag(rollout_percentage: 0.0)
+      stub_flag_definitions([flag])
+      provider.start_polling_for_definitions!
+
+      result = provider.get_variant('test_flag', fallback, test_context)
+      expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
+      expect(result.fallback_reason).to eq(Mixpanel::Flags::FallbackReason::NO_ROLLOUT_MATCH)
+    end
+  end
+
   describe 'polling' do
     it 'uses most recent polled flag definitions' do
       flag_v1 = create_test_flag(rollout_percentage: 0.0)

--- a/spec/mixpanel-ruby/flags/remote_flags_spec.rb
+++ b/spec/mixpanel-ruby/flags/remote_flags_spec.rb
@@ -257,6 +257,18 @@ describe Mixpanel::Flags::RemoteFlagsProvider do
 
       provider.get_variant('any-flag', fallback_variant, test_context)
     end
+
+    it 'tags the fallback as BACKEND_ERROR with the response body on HTTP error (SDK-83)' do
+      stub_request(:get, %r{https://api\.mixpanel\.com/flags})
+        .to_return(status: 400, body: 'distinct_id must be provided in evalContext as a string')
+
+      fallback_variant = Mixpanel::Flags::SelectedVariant.new(variant_value: 'fb')
+      result = provider.get_variant('any-flag', fallback_variant, test_context, report_exposure: false)
+
+      expect(result.variant_source).to eq(Mixpanel::Flags::VariantSource::FALLBACK)
+      expect(result.fallback_reason.kind).to eq(:backend_error)
+      expect(result.fallback_reason.message).to include('distinct_id must be provided')
+    end
   end
 
   describe '#is_enabled' do


### PR DESCRIPTION
## Summary

Bundles two related fixes. Both touch the same `fallback_reason` plumbing so they merge as one PR.

### SDK-79 — distinguish fallback reasons (local eval)

Three local-evaluation outcomes — flag-not-found, no-rollout-match, and missing-context-key — previously all returned the bare developer fallback. The OpenFeature wrapper collapsed them to `FLAG_NOT_FOUND`, sending callers chasing the flag name when the real cause was usually a rule miss or absent context.

`SelectedVariant` now carries two source fields: `variant_source` (`local` / `remote` / `fallback`) and `fallback_reason` (set only when source is `fallback`). The wrapper dispatches on `fallback_reason` and maps each to the spec-correct OpenFeature response — most notably, `NO_ROLLOUT_MATCH` becomes `reason: DEFAULT` with no error code instead of `FLAG_NOT_FOUND`.

### SDK-83 — forward the backend's error message (remote eval)

When the remote `/flags` endpoint returned an error response (e.g. HTTP 400 with "distinct_id must be provided in evalContext as a string"), the catch block returned the fallback variant without attaching the cause. The wrapper saw a fallback and translated to `FLAG_NOT_FOUND` — indistinguishable from a genuinely missing flag. Go propagates these as `GENERAL` with the full backend message; the goal here is to match that.

To carry the message, `FallbackReason` is upgraded from a bare string constant to a small value object with `kind` (the PHP-aligned discriminator) and optional `message` (set on `BACKEND_ERROR` and `MISSING_CONTEXT_KEY`). The remote provider's catch branches tag the fallback with `FallbackReason.backend_error(message)`; the wrapper forwards `message` into OpenFeature's `error_message` / `errorMessage`.

## Fix pattern

### `FallbackReason` kinds (PHP-aligned)

| Kind | When it fires | Carries message? |
| --- | --- | --- |
| `FLAG_NOT_FOUND` | Flag key not in the ruleset / absent from `/flags` response | no |
| `MISSING_CONTEXT_KEY` | Required context attribute (distinct_id / targeting key) absent | the missing attribute name |
| `NO_ROLLOUT_MATCH` | Flag exists, user isn't in any rollout | no |
| `BACKEND_ERROR` | Remote `/flags` error response | the backend's response body (SDK-83) |
| `NOT_READY` | Provider not initialized | no |

### OpenFeature mapping

| Kind | OpenFeature response |
| --- | --- |
| `FLAG_NOT_FOUND` | `error_code: FLAG_NOT_FOUND`, `reason: DEFAULT` |
| `MISSING_CONTEXT_KEY` | `error_code: TARGETING_KEY_MISSING`, `reason: ERROR`, **`error_message: <attribute name>`** |
| `NO_ROLLOUT_MATCH` | `reason: DEFAULT`, no error |
| `BACKEND_ERROR` | `error_code: GENERAL`, `reason: ERROR`, **`error_message: <backend body>`** |
| `NOT_READY` | `error_code: PROVIDER_NOT_READY`, `reason: ERROR` |

## Test plan

- [x] Full base SDK + OpenFeature wrapper test suites pass
- [x] New `BACKEND_ERROR` producer-side test verifies the backend response body propagates through to `fallback_reason.message`
- [x] Wrapper test verifies `error_message` / `errorMessage` forwards the backend message for `BACKEND_ERROR` and the missing-attribute name for `MISSING_CONTEXT_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
