### PR TITLE
fix(analytics): surface dropped exposure when distinct_id missing from context (SDK-84)

### DIFF
--- a/lib/mixpanel-ruby/flags/flags_provider.rb
+++ b/lib/mixpanel-ruby/flags/flags_provider.rb
@@ -88,6 +88,14 @@ module Mixpanel
         distinct_id = context['distinct_id'] || context[:distinct_id]
 
         unless distinct_id
+          # Local eval succeeds when the flag's Variant Assignment Key is
+          # something other than distinct_id (e.g., device_id), but the
+          # exposure event still needs distinct_id to attribute the user.
+          # Surface the drop instead of silently returning so callers can
+          # see they need to include distinct_id in the context.
+          @error_handler&.handle(MixpanelError.new(
+            "Cannot track exposure event for flag '#{flag_key}' without a distinct_id in the context"
+          ))
           return
         end
 

--- a/spec/mixpanel-ruby/flags/local_flags_spec.rb
+++ b/spec/mixpanel-ruby/flags/local_flags_spec.rb
@@ -718,6 +718,29 @@ describe Mixpanel::Flags::LocalFlagsProvider do
 
       provider.send(:track_exposure_event, 'test_flag', variant, test_context)
     end
+
+    # SDK-84: when local eval succeeds via a non-distinct_id Variant Assignment
+    # Key but the context lacks distinct_id, the exposure can't fire. Surface
+    # via error_handler instead of silently returning.
+    it 'reports through error_handler when distinct_id is missing' do
+      variant = Mixpanel::Flags::SelectedVariant.new(
+        variant_key: 'treatment', variant_value: 'treatment'
+      )
+
+      expect(mock_tracker).not_to receive(:call)
+      expect(mock_error_handler).to receive(:handle) do |err|
+        expect(err).to be_a(Mixpanel::MixpanelError)
+        expect(err.message).to include('test_flag')
+        expect(err.message).to include('distinct_id')
+      end
+
+      provider.send(
+        :track_exposure_event,
+        'test_flag',
+        variant,
+        { 'device_id' => 'abc-123' }
+      )
+    end
   end
 
   describe 'polling' do


### PR DESCRIPTION
## Summary

When a flag uses a non-default Variant Assignment Key (e.g. `device_id`) and the evaluation context doesn't include `distinct_id`, local eval succeeds — flag definitions are cached, bucketing only needs the configured key — but `track_exposure_event` then silently `return`s because it can only attribute the exposure event to a `distinct_id`. Caller gets the right flag value with no signal that analytics were dropped.

Pass a `Mixpanel::MixpanelError` to `@error_handler` (consistent with how the rest of the SDK surfaces problems) so the drop becomes visible to anyone who's configured a real handler.

## Context

Linear: [SDK-84](https://linear.app/mixpanel/issue/SDK-84/silent-exposure-drop-when-bucketing-key-isnt-distinct-id). Only `Ruby` and `Java` are actually affected of the five SDKs the audit listed — Python / Go / Node already log when this happens.

This bug only affects **local evaluation**. Remote eval requires `distinct_id` at the eval step itself, so it errors out before reaching exposure tracking.

Behavior when `distinct_id` IS present (alongside the bucketing key) is unchanged — exposure still fires correctly attributed to the user.

## Test plan

- [x] Existing `track_exposure_event` test still passes
- [x] New test asserts `MixpanelError` is reported through `error_handler` when the context has `device_id` but no `distinct_id`
- [x] Full flags spec suite (84 examples) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
