### PR TITLE
fix(analytics): surface polling-loop errors so schema drift can't loop silently (SDK-78)

### DIFF
--- a/lib/mixpanel-ruby/flags/local_flags_provider.rb
+++ b/lib/mixpanel-ruby/flags/local_flags_provider.rb
@@ -49,13 +49,13 @@ module Mixpanel
               begin
                 fetch_flag_definitions
               rescue StandardError => e
-                @error_handler.handle(e) if @error_handler
+                log_polling_error(e)
               end
             end
           end
         end
       rescue StandardError => e
-        @error_handler.handle(e) if @error_handler
+        log_polling_error(e)
       end
 
       def stop_polling_for_definitions!
@@ -140,6 +140,19 @@ module Mixpanel
       end
 
       private
+
+      # Surface polling-loop failures unconditionally. The default
+      # Mixpanel::ErrorHandler is a no-op, so dispatching only via
+      # @error_handler swallows schema drift (NoMethodError,
+      # JSON::ParserError, etc.) — the loop runs forever undetected.
+      # Always warn so the failure is visible without an error_handler
+      # being configured. Matches the convention in mixpanel-python /
+      # mixpanel-java / mixpanel-go / mixpanel-node, all of which log
+      # unconditionally and keep polling.
+      def log_polling_error(error)
+        warn "[Mixpanel] Failed to fetch flag definitions: #{error.class}: #{error.message}"
+        @error_handler.handle(error) if @error_handler
+      end
 
       def fetch_flag_definitions
         response = call_flags_endpoint

--- a/spec/mixpanel-ruby/flags/local_flags_spec.rb
+++ b/spec/mixpanel-ruby/flags/local_flags_spec.rb
@@ -755,5 +755,39 @@ describe Mixpanel::Flags::LocalFlagsProvider do
         polling_provider.stop_polling_for_definitions!
       end
     end
+
+    it 'warns to stderr when fetch raises and no error_handler is configured' do
+      stub_request(:get, endpoint_url_regex).to_return(status: 500, body: 'server down')
+
+      polling_provider = Mixpanel::Flags::LocalFlagsProvider.new(
+        test_token,
+        { enable_polling: false },
+        mock_tracker,
+        nil
+      )
+
+      expect { polling_provider.start_polling_for_definitions! }
+        .to output(/\[Mixpanel\] Failed to fetch flag definitions: Mixpanel::ServerError/).to_stderr
+    end
+
+    it 'surfaces unexpected errors (schema drift) instead of swallowing them silently' do
+      stub_flag_definitions([create_test_flag])
+
+      polling_provider = Mixpanel::Flags::LocalFlagsProvider.new(
+        test_token,
+        { enable_polling: false },
+        mock_tracker,
+        mock_error_handler
+      )
+
+      # Simulate schema drift: server returns a payload the parser doesn't expect.
+      # Without this fix the error would be dispatched only to @error_handler (whose
+      # default ErrorHandler#handle is a no-op) — operators would never notice.
+      allow(polling_provider).to receive(:fetch_flag_definitions).and_raise(NoMethodError, "undefined method `[]' for nil:NilClass")
+
+      expect(mock_error_handler).to receive(:handle).with(an_instance_of(NoMethodError))
+      expect { polling_provider.start_polling_for_definitions! }
+        .to output(/\[Mixpanel\] Failed to fetch flag definitions: NoMethodError/).to_stderr
+    end
   end
 end


### PR DESCRIPTION
## Summary

`start_polling_for_definitions!` caught `StandardError` and dispatched only to `@error_handler`, whose default `Mixpanel::ErrorHandler#handle` is a no-op. Schema drift (`NoMethodError`, `JSON::ParserError`, `TypeError`, …) would loop forever **undetected** unless the user had configured a custom handler — exactly the audit's concern.

Add a `log_polling_error` helper that always `warn`s to `$stderr` before dispatching to `@error_handler`. Visibility no longer depends on configuration; operators see the failure in their logs the moment the next poll hits a bad payload.

## Why a `warn` and not a re-raise

Matches the de facto convention across every other Mixpanel SDK polling loop:

| SDK | Behavior |
| --- | --- |
| mixpanel-python | `logger.exception("Failed to fetch feature flag definitions")`, continue |
| mixpanel-java | `logger.log(Level.WARNING, "Failed to fetch flag definitions", e)`, continue |
| mixpanel-go | `log.Printf("Error polling for flag definitions: %v", err)`, continue |
| mixpanel-node | `this.logger?.error(...)`, continue |

Crashing the polling thread on the first bad payload would freeze local evaluation at whatever variants were last cached — strictly worse than continuing. The audit's complaint was about **detection**, not retry policy.

## Context

Linear: [SDK-78](https://linear.app/mixpanel/issue/SDK-78). Source: Feature Flags & OpenFeature SDK Audit Findings. Ruby was the only affected SDK — the rest already log unconditionally.

Independent of [SDK-81](https://github.com/mixpanel/mixpanel-ruby/pull/155) (the polling-thread-safety fix); changes are in different lines of the same `begin`/`rescue` block and will merge cleanly in either order.

## Test plan

- [x] Full flags spec suite (46 examples) passes
- [x] New `"warns to stderr when fetch raises and no error_handler is configured"` exercises the audit-failure mode directly (provider built with `nil` error_handler + 500 response, asserts the `warn` lands on stderr)
- [x] New `"surfaces unexpected errors (schema drift) instead of swallowing them silently"` injects a `NoMethodError` via `allow(...).to receive(:fetch_flag_definitions)`, asserts **both** the error_handler dispatch AND the stderr warning fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)
